### PR TITLE
Implemented xroad service information fetching, reading, and viewing

### DIFF
--- a/ckanext/xroad_integration/model.py
+++ b/ckanext/xroad_integration/model.py
@@ -3,16 +3,26 @@ import logging
 
 from ckan import model
 from ckan.lib import dictization
-from sqlalchemy import Column, types
+from sqlalchemy import Column, ForeignKey, types, and_
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()
 log = logging.getLogger(__name__)
 
+
 def make_uuid():
     return unicode(uuid.uuid4())
 
-class XRoadError(Base):
+
+class AsDictMixin:
+    def as_dict(self):
+        context = {'model': model}
+        result = dictization.table_dictize(self, context)
+
+        return result
+
+
+class XRoadError(Base, AsDictMixin):
 
     __tablename__ = 'xroad_errors'
 
@@ -27,13 +37,6 @@ class XRoadError(Base):
         model.Session.add(xroad_error)
         model.repo.commit()
 
-    def as_dict(self):
-
-        context = {'model': model}
-        error_dict = dictization.table_dictize(self, context)
-
-        return error_dict
-
     @classmethod
     def get_last_date(cls):
         last = model.Session.query(XRoadError).order_by(XRoadError.created.desc()).first()
@@ -42,7 +45,8 @@ class XRoadError(Base):
         else:
             return None
 
-class XRoadStat(Base):
+
+class XRoadStat(Base, AsDictMixin):
 
     __tablename__ = 'xroad_stats'
 
@@ -53,7 +57,6 @@ class XRoadStat(Base):
     distinct_service_count = Column(types.Integer, nullable=False)
     unknown_service_count = Column(types.Integer, nullable=False)
 
-
     @classmethod
     def create(cls, date, soap_service_count, rest_service_count, distinct_service_count, unknown_service_count):
         xroad_stat = XRoadStat(date=date, soap_service_count=soap_service_count, rest_service_count=rest_service_count,
@@ -62,12 +65,6 @@ class XRoadStat(Base):
 
         model.Session.add(xroad_stat)
         model.repo.commit()
-
-    def as_dict(self):
-        context = {'model': model}
-        stat_dict = dictization.table_dictize(self, context)
-
-        return stat_dict
 
     @classmethod
     def get_by_date(cls, date):
@@ -79,6 +76,153 @@ class XRoadStat(Base):
         model.Session.add(obj)
         model.repo.commit()
 
+
+class XRoadServiceList(Base, AsDictMixin):
+    __tablename__ = 'xroad_service_lists'
+
+    id = Column(types.Integer, primary_key=True)
+    timestamp = Column(types.DateTime, nullable=False)
+
+    @classmethod
+    def create(cls, timestamp):
+        service_list = XRoadServiceList(timestamp=timestamp)
+        model.Session.add(service_list)
+        model.repo.commit()
+        return service_list
+
+    @classmethod
+    def within_range(cls, start, end):
+        return (model.Session.query(XRoadServiceList)
+                .filter(and_(XRoadServiceList.timestamp > start),
+                            (XRoadServiceList.timestamp < end)).all())
+
+    def security_servers(self):
+        return (model.Session.query(XRoadServiceListSecurityServer)
+                .filter(XRoadServiceListSecurityServer.xroad_service_list_id == self.id)
+                .all())
+
+    def members(self):
+        return (model.Session.query(XRoadServiceListMember)
+                .filter(XRoadServiceListMember.xroad_service_list_id == self.id)
+                .all())
+
+    def as_dict_full(self):
+        service_list = self.as_dict()
+        service_list['security_servers'] = [ss.as_dict() for ss in self.security_servers()]
+        service_list['members'] = [m.as_dict_full() for m in self.members()]
+        return service_list
+
+
+class XRoadServiceListSecurityServer(Base, AsDictMixin):
+    __tablename__ = 'xroad_service_list_security_servers'
+
+    id = Column(types.Integer, primary_key=True)
+    xroad_service_list_id = Column(types.Integer, ForeignKey("xroad_service_lists.id"), nullable=False)
+    instance = Column(types.Unicode, nullable=False)
+    member_class = Column(types.Unicode, nullable=False)
+    member_code = Column(types.Unicode, nullable=False)
+    server_code = Column(types.Unicode, nullable=False)
+    address = Column(types.Unicode, nullable=False)
+
+    @classmethod
+    def create(cls, xroad_service_list_id, instance, member_class, member_code, server_code, address):
+        security_server = XRoadServiceListSecurityServer(
+                xroad_service_list_id=xroad_service_list_id,
+                instance=instance,
+                member_class=member_class,
+                member_code=member_code,
+                server_code=server_code,
+                address=address)
+        model.Session.add(security_server)
+        model.repo.commit()
+        return security_server
+
+
+class XRoadServiceListMember(Base, AsDictMixin):
+    __tablename__ = 'xroad_service_list_members'
+
+    id = Column(types.Integer, primary_key=True)
+    xroad_service_list_id = Column(types.Integer, ForeignKey("xroad_service_lists.id"), nullable=False)
+    created = Column(types.DateTime, nullable=False)
+    instance = Column(types.Unicode, nullable=False)
+    member_class = Column(types.Unicode, nullable=False)
+    member_code = Column(types.Unicode, nullable=False)
+    name = Column(types.Unicode, nullable=False)
+
+    @classmethod
+    def create(cls, xroad_service_list_id, created, instance, member_class, member_code, name):
+        member = XRoadServiceListMember(
+                xroad_service_list_id=xroad_service_list_id,
+                created=created,
+                instance=instance,
+                member_class=member_class,
+                member_code=member_code,
+                name=name)
+        model.Session.add(member)
+        model.repo.commit()
+        return member
+
+    def subsystems(self):
+        return (model.Session.query(XRoadServiceListSubsystem)
+                .filter(XRoadServiceListSubsystem.xroad_service_list_member_id == self.id)
+                .all())
+
+    def as_dict_full(self):
+        member = self.as_dict()
+        member['subsystems'] = [s.as_dict_full() for s in self.subsystems()]
+        return member
+
+
+class XRoadServiceListSubsystem(Base, AsDictMixin):
+    __tablename__ = 'xroad_service_list_subsystems'
+
+    id = Column(types.Integer, primary_key=True)
+    xroad_service_list_member_id = Column(types.Integer, ForeignKey("xroad_service_list_members.id"), nullable=False)
+    created = Column(types.DateTime, nullable=False)
+    subsystem_code = Column(types.Unicode, nullable=False)
+
+    @classmethod
+    def create(cls, xroad_service_list_member_id, created, subsystem_code):
+        subsystem = XRoadServiceListSubsystem(
+                xroad_service_list_member_id=xroad_service_list_member_id,
+                created=created,
+                subsystem_code=subsystem_code)
+        model.Session.add(subsystem)
+        model.repo.commit()
+        return subsystem
+
+    def services(self):
+        return (model.Session.query(XRoadServiceListService)
+                .filter(XRoadServiceListService.xroad_service_list_subsystem_id == self.id)
+                .all())
+
+    def as_dict_full(self):
+        subsystem = self.as_dict()
+        subsystem['services'] = [s.as_dict() for s in self.services()]
+        return subsystem
+
+
+class XRoadServiceListService(Base, AsDictMixin):
+    __tablename__ = 'xroad_service_list_services'
+
+    id = Column(types.Integer, primary_key=True)
+    xroad_service_list_subsystem_id = Column(types.Integer, ForeignKey("xroad_service_list_subsystems.id"), nullable=False)
+    created = Column(types.DateTime, nullable=False)
+    service_code = Column(types.Unicode, nullable=False)
+    service_version = Column(types.Unicode, nullable=True)
+
+    @classmethod
+    def create(cls, xroad_service_list_subsystem_id, created, service_code, service_version):
+        service = XRoadServiceListService(
+                xroad_service_list_subsystem_id=xroad_service_list_subsystem_id,
+                created=created,
+                service_code=service_code,
+                service_version=service_version)
+        model.Session.add(service)
+        model.repo.commit()
+        return service
+
+
 def init_table(engine):
     Base.metadata.create_all(engine)
-    log.info("Table for xroad errors is set-up")
+    log.info("Table for xroad data is set-up")

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -64,7 +64,9 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin):
             'fetch_xroad_errors': action.fetch_xroad_errors,
             'xroad_error_list': action.xroad_error_list,
             'fetch_xroad_stats': action.fetch_xroad_stats,
-            'xroad_stats': action.xroad_stats
+            'xroad_stats': action.xroad_stats,
+            'fetch_xroad_service_list': action.fetch_xroad_service_list,
+            'xroad_service_list': action.xroad_service_list
         }
 
     # IAuthFunctions
@@ -75,7 +77,9 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin):
             'xroad_error_list': sysadmin,
             'update_xroad_organizations': sysadmin,
             'fetch_xroad_stats': sysadmin,
-            'xroad_stats': sysadmin
+            'xroad_stats': sysadmin,
+            'fetch_xroad_service_list': sysadmin,
+            'xroad_service_list': sysadmin
         }
 
     # IBlueprint

--- a/ckanext/xroad_integration/templates/admin/xroad_services.html
+++ b/ckanext/xroad_integration/templates/admin/xroad_services.html
@@ -1,0 +1,40 @@
+{% extends "admin/base.html" %}
+
+{% block primary %}
+
+    <table class="table table-bordered" style="table-layout:fixed;" data-module="tablesorter">
+      <caption>{{ h.render_datetime(service_list.timestamp) }}</caption>
+        <thead>
+        <tr>
+            <th>{% trans %}Member{% endtrans %}</th>
+            <th>{% trans %}Subsystem{% endtrans %}</th>
+            <th>{% trans %}Service{% endtrans %}</th>
+            <th>{% trans %}Security servers{% endtrans %}</th>
+            <th>{% trans %}Created{% endtrans %}</th>
+        </tr>
+        </thead>
+        <tbody>
+          {% for m in service_list.members %}
+            {% for ss in m.subsystems %}
+              {% for s in ss.services %}
+                <tr>
+                  <td>{{ m.instance }}.{{ m.member_class }}.{{ m.member_code }}</td>
+                  <td>{{ ss.subsystem_code }}</td>
+                  <td>{{ s.service_code }}{%- if s.service_version %}.{{ s.service_version }}{% endif %}</td>
+                  <td>
+                    <ul style="list-style: none; padding: 0;">
+                      {% for ssrv in m.security_servers %}
+                      <li>{{ ssrv.address }} ({{ ssrv.server_code }})</li>
+                      {% endfor %}
+                    </ul>
+                  </td>
+                  <td>{{ s.created }}
+                </tr>
+            {% endfor %}
+          {% endfor %}
+        {% endfor %}
+        </tbody>
+    </table>
+
+{% endblock %}
+

--- a/ckanext/xroad_integration/templates/admin/xroad_stats.html
+++ b/ckanext/xroad_integration/templates/admin/xroad_stats.html
@@ -1,4 +1,4 @@
-{% extends "page.html" %}
+{% extends "admin/base.html" %}
 
 {% block primary %}
 

--- a/ckanext/xroad_integration/views/xroad.py
+++ b/ckanext/xroad_integration/views/xroad.py
@@ -54,7 +54,6 @@ def services():
         member['security_servers'] = security_servers
 
     return render('/admin/xroad_services.html', extra_vars={'service_list': latest})
-    pass
 
 
 xroad.add_url_rule(u'/services', view_func=services)

--- a/ckanext/xroad_integration/views/xroad.py
+++ b/ckanext/xroad_integration/views/xroad.py
@@ -5,6 +5,7 @@ from ckan.plugins.toolkit import render, check_access, NotAuthorized, abort, _, 
 
 xroad = Blueprint(u'xroad', __name__, url_prefix=u'/ckan-admin/xroad')
 
+
 def errors(date=None):
     try:
         context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
@@ -15,6 +16,7 @@ def errors(date=None):
     error_list = get_action('xroad_error_list')({}, {"date": date})
 
     return render('admin/xroad_errors.html', extra_vars={"error_list": error_list})
+
 
 xroad.add_url_rule(u'/errors/<date>', view_func=errors, strict_slashes=False)
 xroad.add_url_rule(u'/errors', view_func=errors, strict_slashes=False)
@@ -31,7 +33,32 @@ def stats():
 
     return render('/admin/xroad_stats.html', extra_vars={'xroad_stats': xroad_stats})
 
+
 xroad.add_url_rule(u'/stats', view_func=stats)
+
+
+def services():
+    try:
+        context = dict(model=model, user=g.user, auth_user_obj=g.userobj)
+        check_access(u'sysadmin', context)
+    except NotAuthorized:
+        abort(403, _(u'Need to be system administrator to administer'))
+
+    xroad_services = get_action('xroad_service_list')({}, {})
+    latest = max(iter(xroad_services), key=lambda x: x['timestamp']) if xroad_services else None
+    members = latest['members'] if latest else []
+
+    for member in members:
+        security_servers = [ss for ss in latest['security_servers']
+                            if all(ss[key] == member[key] for key in ('instance', 'member_class', 'member_code'))]
+        member['security_servers'] = security_servers
+
+    return render('/admin/xroad_services.html', extra_vars={'service_list': latest})
+    pass
+
+
+xroad.add_url_rule(u'/services', view_func=services)
+
 
 def get_blueprints():
     return [xroad]


### PR DESCRIPTION
- Added a data model for service listings
- `fetch_xroad_services_list` action uses the X-Road catalog REST endpoint to fetch and store a set of service lists
- `xroad_services_list` action reads the information for a given period of time
- `xroad.services` view shows the latest information in a tabular format