### PR TITLE
Make actions workflow green

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,12 +53,12 @@ jobs:
           # Replace default path to CKAN core config file with the one on the container
           sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
       - name: Setup extension (CKAN >= 2.9)
-        if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' }}
+        if: ${{ matrix.ckan-version != '2.8' }}
         run: |
           ckan -c test.ini db init
           ckan -c test.ini xroad init_db
       - name: Setup extension (CKAN < 2.9)
-        if: ${{ matrix.ckan-version == '2.7' || matrix.ckan-version == '2.8' }}
+        if: ${{ matrix.ckan-version == '2.8' }}
         run: |
           paster --plugin=ckan db init -c test.ini
           paster --plugin=ckanext-xroad_integration xroad init_db -c test.ini

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,7 @@ jobs:
         if: ${{ matrix.ckan-version != '2.8' }}
         run: |
           ckan -c test.ini db init
-          ckan -c test.ini xroad
-          ckan -c test.ini xroad init_db
+          ckan -c test.ini xroad init-db
       - name: Setup extension (CKAN < 2.9)
         if: ${{ matrix.ckan-version == '2.8' }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,7 @@ jobs:
         if: ${{ matrix.ckan-version != '2.8' }}
         run: |
           ckan -c test.ini db init
+          ckan -c test.ini xroad
           ckan -c test.ini xroad init_db
       - name: Setup extension (CKAN < 2.9)
         if: ${{ matrix.ckan-version == '2.8' }}

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+
+import ckantoolkit as tk
+import click
+
+import ckanext.xroad_integration.utils as utils
+
+
+
+def get_commands():
+    return [xroad]
+
+
+@click.group()
+def xroad():
+    """X-Road related commands.
+    """
+    pass
+
+
+@xroad.command()
+def initdb():
+    """Creates the necessary tables in the database.
+    """
+    utils.initdb()
+    click.secho(u"DB tables created", fg=u"green")

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -20,7 +20,7 @@ def xroad():
 
 
 @xroad.command()
-def initdb():
+def init_db():
     """Creates the necessary tables in the database.
     """
     utils.init_db()

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -1,12 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import click
 
 import ckanext.xroad_integration.utils as utils
-
-
 
 def get_commands():
     return [xroad]

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import click
+from ckan.lib.cli import click_config_option
 
 import ckanext.xroad_integration.utils as utils
 
@@ -21,3 +22,51 @@ def init_db():
     """
     utils.init_db()
     click.secho(u"DB tables created", fg=u"green")
+
+@xroad.command(
+    u'update_xroad_organizations',
+    help='Updates harvested organizations\' metadata'
+)
+@click_config_option
+@click.pass_context
+def update_xroad_organizations(ctx, config):
+    flask_app = ctx.meta["flask_app"]
+    with flask_app.test_request_context():
+        utils.update_xroad_organization()
+
+@xroad.command(
+    u'fetch_errors',
+    help='Fetches error log from catalog lister'
+)
+@click_config_option
+@click.pass_context
+def fetch_errors(ctx, config):
+    flask_app = ctx.meta["flask_app"]
+    with flask_app.test_request_context():
+        utils.fetch_errors()
+
+@xroad.command(
+    u'fetch_stats',
+    help='Fetches X-Road stats from catalog lister'
+)
+@click_config_option
+@click.pass_context
+@click.option(u'--days', type=int)
+def fetch_stats(ctx, config, days):
+
+    flask_app = ctx.meta["flask_app"]
+    with flask_app.test_request_context():
+        utils.fetch_stats(days)
+
+@xroad.command(
+    u'fetch_service_list',
+    help='Fetches X-Road services from catalog lister'
+)
+@click_config_option
+@click.pass_context
+@click.option(u'--days', type=int)
+def fetch_service_list(ctx, config, days):
+
+    flask_app = ctx.meta["flask_app"]
+    with flask_app.test_request_context():
+        utils.fetch_service_list(days)

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import click
-from ckan.lib.cli import click_config_option
 
 import ckanext.xroad_integration.utils as utils
 
@@ -27,7 +26,6 @@ def init_db():
     u'update_xroad_organizations',
     help='Updates harvested organizations\' metadata'
 )
-@click_config_option
 @click.pass_context
 def update_xroad_organizations(ctx, config):
     flask_app = ctx.meta["flask_app"]
@@ -38,7 +36,6 @@ def update_xroad_organizations(ctx, config):
     u'fetch_errors',
     help='Fetches error log from catalog lister'
 )
-@click_config_option
 @click.pass_context
 def fetch_errors(ctx, config):
     flask_app = ctx.meta["flask_app"]
@@ -49,7 +46,6 @@ def fetch_errors(ctx, config):
     u'fetch_stats',
     help='Fetches X-Road stats from catalog lister'
 )
-@click_config_option
 @click.pass_context
 @click.option(u'--days', type=int)
 def fetch_stats(ctx, config, days):
@@ -62,7 +58,6 @@ def fetch_stats(ctx, config, days):
     u'fetch_service_list',
     help='Fetches X-Road services from catalog lister'
 )
-@click_config_option
 @click.pass_context
 @click.option(u'--days', type=int)
 def fetch_service_list(ctx, config, days):

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -23,5 +23,5 @@ def xroad():
 def initdb():
     """Creates the necessary tables in the database.
     """
-    utils.initdb()
+    utils.init_db()
     click.secho(u"DB tables created", fg=u"green")

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import ckantoolkit as tk
 import click
 
 import ckanext.xroad_integration.utils as utils

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -99,4 +99,5 @@ def init_db(ctx, config):
     init_table(model.meta.engine)
 
 def get_commands():
+    print("get_commands call")
     return [xroad]

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -1,15 +1,16 @@
 import click
 
-from ckan.lib.cli import load_config, paster_click_group, click_config_option
+from ckan.lib.cli import load_config, click_config_option
 from ckan.plugins.toolkit import get_action
 
 
-xroad_commands = paster_click_group(
-    summary=u'X-Road related commands'
-)
+@click.group()
+def xroad():
+    """X-Road related commands"""
+    pass
 
 
-@xroad_commands.command(
+@xroad.command(
     u'update_xroad_organizations',
     help='Updates harvested organizations\' metadata'
 )
@@ -20,7 +21,7 @@ def update_xroad_organizations(ctx, config):
     get_action('update_xroad_organizations')({'ignore_auth': True}, {})
 
 
-@xroad_commands.command(
+@xroad.command(
     u'fetch_errors',
     help='Fetches error log from catalog lister'
 )
@@ -38,7 +39,7 @@ def fetch_errors(ctx, config):
         print(results['message'])
 
 
-@xroad_commands.command(
+@xroad.command(
     u'fetch_stats',
     help='Fetches X-Road stats from catalog lister'
 )
@@ -61,7 +62,7 @@ def fetch_stats(ctx, config, days):
         print(results['message'])
 
 
-@xroad_commands.command(
+@xroad.command(
     u'fetch_service_list',
     help='Fetches X-Road services from catalog lister'
 )
@@ -84,7 +85,7 @@ def fetch_service_list(ctx, config, days):
         print("Error fetching service list!")
 
 
-@xroad_commands.command(
+@xroad.command(
     u'init_db',
     help="Initializes databases for xroad"
 )
@@ -98,4 +99,4 @@ def init_db(ctx, config):
     init_table(model.meta.engine)
 
 def get_commands():
-    return [xroad_commands]
+    return [xroad]

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -99,5 +99,4 @@ def init_db(ctx, config):
     init_table(model.meta.engine)
 
 def get_commands():
-    print("get_commands call")
     return [xroad]

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -18,7 +18,7 @@ xroad_commands = paster_click_group(
 @click.pass_context
 def update_xroad_organizations(ctx, config):
     load_config(config or ctx.obj['config'])
-    get_action('update_xroad_organizations')({'ignore_auth': True}, {})
+    utils.update_xroad_organizations
 
 
 @xroad_commands.command(
@@ -29,14 +29,7 @@ def update_xroad_organizations(ctx, config):
 @click.pass_context
 def fetch_errors(ctx, config):
     load_config((config or ctx.obj['config']))
-    results = get_action('fetch_xroad_errors')({'ignore_auth': True}, {})
-
-    if results.get("success") is True:
-        for result in results.get('results', []):
-            print(result['message'])
-
-    else:
-        print(results['message'])
+    utils.fetch_errors()
 
 
 @xroad_commands.command(
@@ -49,17 +42,7 @@ def fetch_errors(ctx, config):
 def fetch_stats(ctx, config, days):
     load_config((config or ctx.obj['config']))
 
-    data_dict = {}
-    if days:
-        data_dict['days'] = days
-
-    results = get_action('fetch_xroad_stats')({'ignore_auth': True}, data_dict)
-
-    if results.get("success") is True:
-        print(results['message'])
-
-    else:
-        print(results['message'])
+    utils.fetch_stats(days)
 
 
 @xroad_commands.command(
@@ -71,18 +54,7 @@ def fetch_stats(ctx, config, days):
 @click.option(u'--days', type=int)
 def fetch_service_list(ctx, config, days):
     load_config((config or ctx.obj['config']))
-
-    data_dict = {}
-    if days:
-        data_dict['days'] = days
-
-    results = get_action('fetch_xroad_service_list')({'ignore_auth': True}, data_dict)
-
-    if results.get("success") is True:
-        print(results['message'])
-
-    else:
-        print("Error fetching service list!")
+    utils.fetch_service_list(days)
 
 
 @xroad_commands.command(

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -1,16 +1,16 @@
 import click
 
-from ckan.lib.cli import load_config, click_config_option
+from ckan.lib.cli import load_config, click_config_option, paster_click_group
 from ckan.plugins.toolkit import get_action
+import ckanext.xroad_integration.utils as utils
 
 
-@click.group()
-def xroad():
-    """X-Road related commands"""
-    pass
+xroad_commands = paster_click_group(
+        summary=u'X-Road related commands'
+)
 
 
-@xroad.command(
+@xroad_commands.command(
     u'update_xroad_organizations',
     help='Updates harvested organizations\' metadata'
 )
@@ -21,7 +21,7 @@ def update_xroad_organizations(ctx, config):
     get_action('update_xroad_organizations')({'ignore_auth': True}, {})
 
 
-@xroad.command(
+@xroad_commands.command(
     u'fetch_errors',
     help='Fetches error log from catalog lister'
 )
@@ -39,7 +39,7 @@ def fetch_errors(ctx, config):
         print(results['message'])
 
 
-@xroad.command(
+@xroad_commands.command(
     u'fetch_stats',
     help='Fetches X-Road stats from catalog lister'
 )
@@ -62,7 +62,7 @@ def fetch_stats(ctx, config, days):
         print(results['message'])
 
 
-@xroad.command(
+@xroad_commands.command(
     u'fetch_service_list',
     help='Fetches X-Road services from catalog lister'
 )
@@ -85,7 +85,7 @@ def fetch_service_list(ctx, config, days):
         print("Error fetching service list!")
 
 
-@xroad.command(
+@xroad_commands.command(
     u'init_db',
     help="Initializes databases for xroad"
 )
@@ -94,9 +94,4 @@ def fetch_service_list(ctx, config, days):
 def init_db(ctx, config):
     load_config((config or ctx.obj['config']))
 
-    import ckan.model as model
-    from ckanext.xroad_integration.model import init_table
-    init_table(model.meta.engine)
-
-def get_commands():
-    return [xroad]
+    utils.init_db()

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -96,3 +96,6 @@ def init_db(ctx, config):
     import ckan.model as model
     from ckanext.xroad_integration.model import init_table
     init_table(model.meta.engine)
+
+def get_commands():
+    return [xroad_commands]

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -4,9 +4,9 @@ from ckan.lib.plugins import DefaultTranslation
 from ckan.logic.auth.get import sysadmin
 
 import ckanext.xroad_integration.helpers as helpers
-from views import xroad
-from logic import action
-from auth import xroad_error_list
+from ckanext.xroad_integration.views import xroad
+from ckanext.xroad_integration.logic import action
+from ckanext.xroad_integration.auth import xroad_error_list
 
 import ckanext.xroad_integration.cli as cli
 

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -3,7 +3,7 @@ import ckan.plugins.toolkit as toolkit
 from ckan.lib.plugins import DefaultTranslation
 from ckan.logic.auth.get import sysadmin
 
-import helpers
+import helpers as helpers
 from views import xroad
 from logic import action
 from auth import xroad_error_list

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -8,7 +8,7 @@ from views import xroad
 from logic import action
 from auth import xroad_error_list
 
-from .commands import xroad as cli
+from .cli import xroad as cli
 
 class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -8,7 +8,7 @@ from views import xroad
 from logic import action
 from auth import xroad_error_list
 
-from .cli import xroad as cli
+import cli as cli
 
 class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -8,6 +8,7 @@ from views import xroad
 from logic import action
 from auth import xroad_error_list
 
+from .commands import xroad as cli
 
 class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)
@@ -18,6 +19,9 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.ITranslation)
+
+    if toolkit.check_ckan_version(min_version="2.9"):
+        plugins.implements(plugins.IClick)
 
     # IConfigurer
 
@@ -87,3 +91,8 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IBlueprint
     def get_blueprint(self):
         return xroad.get_blueprints()
+
+    # IClick
+
+    def get_commands(self):
+        return cli.get_commands()

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -3,12 +3,12 @@ import ckan.plugins.toolkit as toolkit
 from ckan.lib.plugins import DefaultTranslation
 from ckan.logic.auth.get import sysadmin
 
-import helpers as helpers
+import ckanext.xroad_integration.helpers as helpers
 from views import xroad
 from logic import action
 from auth import xroad_error_list
 
-import cli as cli
+import ckanext.xroad_integration.cli as cli
 
 class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)

--- a/ckanext/xroad_integration/utils.py
+++ b/ckanext/xroad_integration/utils.py
@@ -1,0 +1,4 @@
+def init_db():
+    import ckan.model as model
+    from ckanext.xroad_integration.model import init_table
+    init_table(model.meta.engine)

--- a/ckanext/xroad_integration/utils.py
+++ b/ckanext/xroad_integration/utils.py
@@ -1,4 +1,48 @@
+from ckan.plugins.toolkit import get_action
+
 def init_db():
     import ckan.model as model
     from ckanext.xroad_integration.model import init_table
     init_table(model.meta.engine)
+
+def update_xroad_organizations():
+    get_action('update_xroad_organizations')({'ignore_auth': True}, {})
+
+def fetch_errors():
+    results = get_action('fetch_xroad_errors')({'ignore_auth': True}, {})
+
+    if results.get("success") is True:
+        for result in results.get('results', []):
+            print(result['message'])
+
+    else:
+        print(results['message'])
+
+
+def fetch_stats(days):
+
+    data_dict = {}
+    if days:
+        data_dict['days'] = days
+
+    results = get_action('fetch_xroad_stats')({'ignore_auth': True}, data_dict)
+
+    if results.get("success") is True:
+        print(results['message'])
+
+    else:
+        print(results['message'])
+
+
+def fetch_service_list(days):
+    data_dict = {}
+    if days:
+        data_dict['days'] = days
+
+    results = get_action('fetch_xroad_service_list')({'ignore_auth': True}, data_dict)
+
+    if results.get("success") is True:
+        print(results['message'])
+
+    else:
+        print("Error fetching service list!")

--- a/ckanext/xroad_integration/views/xroad.py
+++ b/ckanext/xroad_integration/views/xroad.py
@@ -7,7 +7,10 @@ from flask import request, make_response
 import logging
 import csv
 
-from ckanext.apicatalog_ui.plugin import get_translated
+try:
+    from ckanext.apicatalog_ui.plugin import get_translated
+except ImportError:
+    from ckan.lib.helpers import get_translated
 
 xroad = Blueprint(u'xroad', __name__, url_prefix=u'/ckan-admin/xroad')
 log = logging.getLogger(__name__)

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan
         [paste.paster_command]
-        xroad = ckanext.xroad_integration.commands.xroad:xroad_commands
+        xroad = ckanext.xroad_integration.commands.xroad:xroad
     ''',
 
     # If you are changing from the default layout of your extension, you may

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan
         [paste.paster_command]
-        xroad = ckanext.xroad_integration.commands.xroad:xroad
+        xroad = ckanext.xroad_integration.commands.xroad:xroad_commands
     ''',
 
     # If you are changing from the default layout of your extension, you may

--- a/test.ini
+++ b/test.ini
@@ -14,6 +14,8 @@ use = config:../ckan/test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here.
 ckan.plugins = xroad_integration
+ckanext.xroad_integration.xroad_catalog_address = "localhost"
+ckanext.xroad_integration.xroad_client_id = "someid"
 
 
 # Logging configuration

--- a/test.ini
+++ b/test.ini
@@ -13,6 +13,7 @@ use = config:../ckan/test-core.ini
 
 # Insert any custom config settings to be used when running your extension's
 # tests here.
+ckan.plugins = xroad_integration
 
 
 # Logging configuration


### PR DESCRIPTION
Support for new IClick interface, both old ckan command and the new cli is supported.
Python3 fixes.
Fallback for core get_translated to remove dependency on apicatalog_ui. 