### PR TITLE
LIKA-300: Batch run results

### DIFF
--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -22,6 +22,18 @@ def init_db():
     utils.init_db()
     click.secho(u"DB tables created", fg=u"green")
 
+@xroad.command()
+@click.option(u'--yes-i-am-sure')
+def drop_db(yes_i_am_sure):
+    """Removes tables created by init_db in the database.
+    """
+    if yes_i_am_sure:
+        utils.drop_db()
+        click.secho(u"DB tables dropped", fg=u"green")
+    else:
+        click.secho(u"This will delete all xroad data in the database! If you are sure, run this command with the --yes-i-am-sure option.", fg=u"yellow")
+
+
 @xroad.command(
     u'update_xroad_organizations',
     help='Updates harvested organizations\' metadata'

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -18,7 +18,7 @@ xroad_commands = paster_click_group(
 @click.pass_context
 def update_xroad_organizations(ctx, config):
     load_config(config or ctx.obj['config'])
-    utils.update_xroad_organizations
+    utils.update_xroad_organizations()
 
 
 @xroad_commands.command(
@@ -58,6 +58,28 @@ def fetch_service_list(ctx, config, days):
 
 
 @xroad_commands.command(
+    u'latest_batch_run_results',
+    help='Prints the results of the latest batch runs'
+)
+@click_config_option
+@click.pass_context
+def latest_batch_run_results(ctx, config):
+    load_config((config or ctx.obj['config']))
+    results = utils.latest_batch_run_results()
+
+    columns = ['service', 'result', 'timestamp', 'message']
+    rows = [[r.get('service'),
+             'success' if r.get('success') else 'failure',
+             r.get('timestamp'),
+             r.get('message') or '']
+            for r in results]
+
+    row_format = '{:<30} {:<10} {:<28} {}'
+    print(row_format.format(*columns))
+    print('\n'.join(row_format.format(*row) for row in rows))
+
+
+@xroad_commands.command(
     u'init_db',
     help="Initializes databases for xroad"
 )
@@ -67,3 +89,18 @@ def init_db(ctx, config):
     load_config((config or ctx.obj['config']))
 
     utils.init_db()
+
+
+@xroad_commands.command(
+        u'drop_db',
+        help='Removes tables created by init_db in the database.')
+@click.option(u'--yes-i-am-sure/--no-i-am-not-sure', default=False)
+@click_config_option
+@click.pass_context
+def drop_db(ctx, config, yes_i_am_sure):
+    load_config((config or ctx.obj['config']))
+    if yes_i_am_sure:
+        utils.drop_db()
+        click.secho(u"DB tables dropped", fg=u"green")
+    else:
+        click.secho(u"This will delete all xroad data in the database! If you are sure, run this command with the --yes-i-am-sure option.", fg=u"yellow")

--- a/ckanext/xroad_integration/commands/xroad.py
+++ b/ckanext/xroad_integration/commands/xroad.py
@@ -2,7 +2,11 @@ import click
 
 from ckan.lib.cli import load_config, click_config_option, paster_click_group
 from ckan.plugins.toolkit import get_action
+import ckan.plugins.toolkit as toolkit
 import ckanext.xroad_integration.utils as utils
+import ckan.lib.mailer as mailer
+from datetime import datetime
+import jinja2
 
 
 xroad_commands = paster_click_group(
@@ -104,3 +108,57 @@ def drop_db(ctx, config, yes_i_am_sure):
         click.secho(u"DB tables dropped", fg=u"green")
     else:
         click.secho(u"This will delete all xroad data in the database! If you are sure, run this command with the --yes-i-am-sure option.", fg=u"yellow")
+
+
+@xroad_commands.command(
+        u'send_latest_batch_run_results_email',
+        help='Sends emails to configured addresses if a previous batch run has failed')
+@click.option(u'--dryrun', is_flag=True)
+@click_config_option
+@click.pass_context
+def send_latest_batch_run_results_email(ctx, config, dryrun):
+    load_config((config or ctx.obj['config']))
+    results = utils.latest_batch_run_results()
+    failed = [r for r in results if r.get('success') is not True]
+
+    if not failed:
+        print('Previous runs for all batch operations were successful')
+        return
+
+    email_notification_recipients = toolkit.aslist(toolkit.config.get('ckanext.apicatalog.harvester_status_recipients', ''))
+
+    if not email_notification_recipients and not dryrun:
+        print('No recipients configured')
+        return
+
+    site_title = toolkit.config.get('ckan.site_title', '')
+    today = datetime.now().date().isoformat()
+
+    columns = ['service', 'result', 'timestamp', 'message']
+    rows = [[r.get('service'),
+             'success' if r.get('success') else 'failure',
+             r.get('timestamp'),
+             r.get('message') or '']
+            for r in results]
+
+    jinja_env = jinja2.Environment(loader=jinja2.PackageLoader('ckanext.xroad_integration', 'templates'))
+    template = jinja_env.get_template('email/batch_run_results.html')
+    msg = template.render(columns=columns, rows=rows)
+
+    for recipient in email_notification_recipients:
+        email = {'recipient_name': '',
+                 'recipient_email': recipient,
+                 'subject': '%s - Batch run summary %s' % (site_title, today),
+                 'body': msg,
+                 'headers': {'Content-Type': 'text/html'}}
+
+        if dryrun:
+            print('to: %s' % recipient)
+        else:
+            try:
+                mailer.mail_recipient(**email)
+            except mailer.MailerException as e:
+                print('Sending batch run results to %s failed: %s' % (recipient, e))
+
+    if dryrun:
+        print(msg)

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -66,7 +66,7 @@ def update_xroad_organizations(context, data_dict):
     organization_names = organization_list(context, {})
     timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
 
-    harvest_source_error_limit = 2
+    harvest_source_error_limit = 10
 
     errors_by_source = {}
 

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -70,6 +70,8 @@ def update_xroad_organizations(context, data_dict):
 
     errors_by_source = {}
 
+    updated = 0
+
     for harvest_source in harvest_sources:
         if harvest_source.get('type') != 'xroad':
             continue
@@ -83,7 +85,6 @@ def update_xroad_organizations(context, data_dict):
             continue
 
         errors = []
-        updated = 0
 
         for organization_name in organization_names:
             organization = organization_show(context, {'id': organization_name})

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -72,7 +72,9 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'fetch_xroad_stats': action.fetch_xroad_stats,
             'xroad_stats': action.xroad_stats,
             'fetch_xroad_service_list': action.fetch_xroad_service_list,
-            'xroad_service_list': action.xroad_service_list
+            'xroad_service_list': action.xroad_service_list,
+            'xroad_batch_result_create': action.xroad_batch_result_create,
+            'xroad_latest_batch_results': action.xroad_latest_batch_results,
         }
 
     # IAuthFunctions
@@ -85,7 +87,8 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'fetch_xroad_stats': sysadmin,
             'xroad_stats': sysadmin,
             'fetch_xroad_service_list': sysadmin,
-            'xroad_service_list': sysadmin
+            'xroad_service_list': sysadmin,
+            'xroad_batch_result': sysadmin,
         }
 
     # IBlueprint

--- a/ckanext/xroad_integration/templates/email/batch_run_results.html
+++ b/ckanext/xroad_integration/templates/email/batch_run_results.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+<style>
+tr {
+  padding-bottom: 0.2em;
+}
+td {
+  padding-right: 2em;
+}
+th {
+  text-align: left;
+}
+</style>
+</head>
+<body>
+  <table>
+    <thead>
+      <tr>
+        {% for column in columns %}<th>{{ column }}</th>{% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        {% for cell in row %}<td>{{ cell }}</td>{% endfor %}
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</body>
+</html>

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -41,6 +41,16 @@ def xroad_rest_adapter_mocks():
         mock_proc.join()
 
 
+@pytest.fixture(scope='module')
+def xroad_database_setup():
+    from ckanext.xroad_integration.utils import init_db, drop_db
+
+    init_db()
+
+    yield
+
+    drop_db()
+
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
 @pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
 def test_base(xroad_rest_adapter_mocks):
@@ -98,3 +108,16 @@ def test_delete(xroad_rest_adapter_mocks):
     # assert(should_be_removed_org.get('state') == 'deleted')
     assert(results['TEST.ORG.000003-3.EmptySubsystem']['report_status'] == 'deleted')
     assert(set(r['name'] for r in large.get('resources', [])) == set(['openapiService.1', 'unknown', 'unknownWithVersion.1']))
+
+
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
+def test_update_xroad_organizations(xroad_rest_adapter_mocks):
+    call_action('update_xroad_organizations')
+
+
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
+def test_xroad_errors(xroad_rest_adapter_mocks, xroad_database_setup):
+    call_action('fetch_xroad_errors')
+    call_action('xroad_error_list')

--- a/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_adapter_mock.py
+++ b/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_adapter_mock.py
@@ -130,6 +130,12 @@ def instance(data_path, app_name='xroad_rest_adapter_mock'):
         return jsonify({'companyList': {'company': {}}})
 
 
+    @app.route('/rest-adapter-service/Consumer/GetErrors')
+    def get_errors():
+        since = request.args.get('since')
+        return jsonify({'errorLogList': {'errorLog': []}})
+
+
     def find_member(data, xroad_instance, member_class, member_code):
         return next((m for m in xroad_list_to_list(data, 'memberList', 'member')
                     if m.get('xRoadInstance') == xroad_instance

--- a/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
+++ b/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
@@ -7,19 +7,34 @@ from datetime import datetime, timedelta
 app = Flask(__name__)
 
 
-@app.route('/getListOfServices/<int:days>')
-def getListOfServices(days=1):
-    now = datetime.now()
-    mock_data = json.load(open('getListOfServices.json', 'r', encoding='utf-8'))
-    member_data = []
-    for i in range(days):
-        dt = now - timedelta(days=i)
-        date = [dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond]
-        member_data.append({'date': date, 'memberDataList': mock_data['memberData'][0]['memberDataList']})
+def create_app(input_file):
+    app = Flask(__name__)
+    mock_data = json.load(open(input_file, 'r', encoding='utf-8'))
 
-    data = {'memberData': member_data, 'securityServerData': mock_data['securityServerData']}
-    return json.dumps(data)
+    @app.route('/getListOfServices/<int:days>')
+    def getListOfServices(days=1):
+        now = datetime.now()
+        member_data = []
+        for i in range(days):
+            dt = now - timedelta(days=i)
+            date = [dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond]
+            member_data.append({'date': date, 'memberDataList': mock_data['memberData'][0]['memberDataList']})
+
+        data = {'memberData': member_data, 'securityServerData': mock_data['securityServerData']}
+        return json.dumps(data)
+
+    @app.route('/getServiceStatistics/<int:days>')
+    def getServiceStatistics(days=1):
+        return json.dumps({'serviceStatisticsList': []})
+
+    return app
 
 
 if __name__ == '__main__':
-    app.run(port=8088)
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument('input_file')
+    parser.add_argument('port', nargs='?', type=int, default=8088)
+    args = parser.parse_args()
+    app = create_app(args.input_file)
+    app.run(port=args.port)

--- a/ckanext/xroad_integration/utils.py
+++ b/ckanext/xroad_integration/utils.py
@@ -14,7 +14,11 @@ def drop_db():
 
 
 def update_xroad_organizations():
-    result = get_action('update_xroad_organizations')({'ignore_auth': True}, {})
+    try:
+        result = get_action('update_xroad_organizations')({'ignore_auth': True}, {})
+    except Exception as e:
+        result = {'success': False, 'message': 'Exception: {}'.format(e)}
+
     success = result.get('success') is True
     get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'update_xroad_organizations',
                                                                     'success': success,
@@ -22,7 +26,10 @@ def update_xroad_organizations():
 
 
 def fetch_errors():
-    results = get_action('fetch_xroad_errors')({'ignore_auth': True}, {})
+    try:
+        results = get_action('fetch_xroad_errors')({'ignore_auth': True}, {})
+    except Exception as e:
+        results = {'success': False, 'message': 'Exception: {}'.format(e)}
 
     success = results.get('success') is True
     get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'fetch_xroad_errors',
@@ -43,7 +50,11 @@ def fetch_stats(days):
     if days:
         data_dict['days'] = days
 
-    results = get_action('fetch_xroad_stats')({'ignore_auth': True}, data_dict)
+    try:
+        results = get_action('fetch_xroad_stats')({'ignore_auth': True}, data_dict)
+    except Exception as e:
+        results = {'success': False, 'message': 'Exception: {}'.format(e)}
+
     success = results.get('success') is True
     get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'fetch_xroad_stats',
                                                                     'success': success,
@@ -62,7 +73,11 @@ def fetch_service_list(days):
     if days:
         data_dict['days'] = days
 
-    results = get_action('fetch_xroad_service_list')({'ignore_auth': True}, data_dict)
+    try:
+        results = get_action('fetch_xroad_service_list')({'ignore_auth': True}, data_dict)
+    except Exception as e:
+        results = {'success': False, 'message': 'Exception: {}'.format(e)}
+
     success = results.get('success') is True
     get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'fetch_xroad_service_list',
                                                                     'success': success,

--- a/ckanext/xroad_integration/utils.py
+++ b/ckanext/xroad_integration/utils.py
@@ -1,17 +1,35 @@
 from ckan.plugins.toolkit import get_action
+import json
 
 def init_db():
     import ckan.model as model
     from ckanext.xroad_integration.model import init_table
     init_table(model.meta.engine)
 
+
+def drop_db():
+    import ckan.model as model
+    from ckanext.xroad_integration.model import drop_table
+    drop_table(model.meta.engine)
+
+
 def update_xroad_organizations():
-    get_action('update_xroad_organizations')({'ignore_auth': True}, {})
+    result = get_action('update_xroad_organizations')({'ignore_auth': True}, {})
+    success = result.get('success') is True
+    get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'update_xroad_organizations',
+                                                                    'success': success,
+                                                                    'message': result.get('message')})
+
 
 def fetch_errors():
     results = get_action('fetch_xroad_errors')({'ignore_auth': True}, {})
 
-    if results.get("success") is True:
+    success = results.get('success') is True
+    get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'fetch_xroad_errors',
+                                                                    'success': success,
+                                                                    'message': results.get('message')})
+
+    if success:
         for result in results.get('results', []):
             print(result['message'])
 
@@ -26,8 +44,13 @@ def fetch_stats(days):
         data_dict['days'] = days
 
     results = get_action('fetch_xroad_stats')({'ignore_auth': True}, data_dict)
+    success = results.get('success') is True
+    get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'fetch_xroad_stats',
+                                                                    'success': success,
+                                                                    'params': json.dumps(data_dict),
+                                                                    'message': results.get('message')})
 
-    if results.get("success") is True:
+    if success:
         print(results['message'])
 
     else:
@@ -40,9 +63,20 @@ def fetch_service_list(days):
         data_dict['days'] = days
 
     results = get_action('fetch_xroad_service_list')({'ignore_auth': True}, data_dict)
+    success = results.get('success') is True
+    get_action('xroad_batch_result_create')({'ignore_auth': True}, {'service': 'fetch_xroad_service_list',
+                                                                    'success': success,
+                                                                    'params': json.dumps(data_dict),
+                                                                    'message': results.get('message')})
 
-    if results.get("success") is True:
+    if success:
         print(results['message'])
 
     else:
         print("Error fetching service list!")
+
+
+def latest_batch_run_results():
+    response = get_action('xroad_latest_batch_results')({'ignore_auth': True}, {})
+    return response['results']
+


### PR DESCRIPTION
- Batch run result log
  - Implement a batch run result log: `model.XRoadBatchResult`, `logic.action.xroad_batch_result_create`, `logic.action.xroad_latest_batch_results`
  - Implement a paster command for viewing the latest results
  - Instrument existing paster batch run commands to report their outcomes to the batch run result log
- Implemented a paster command for dropping xroad database tables
- Generally improved error handling and failure states
- Extended xroad mock servers