### PR TITLE
LIKA-395: Implement X-Road catalog heartbeat fetch/read

### DIFF
--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -4,6 +4,7 @@ import click
 
 import ckanext.xroad_integration.utils as utils
 
+
 def get_commands():
     return [xroad]
 
@@ -22,6 +23,7 @@ def init_db():
     utils.init_db()
     click.secho(u"DB tables created", fg=u"green")
 
+
 @xroad.command()
 @click.option(u'--yes-i-am-sure')
 def drop_db(yes_i_am_sure):
@@ -34,46 +36,48 @@ def drop_db(yes_i_am_sure):
         click.secho(u"This will delete all xroad data in the database! If you are sure, run this command with the --yes-i-am-sure option.", fg=u"yellow")
 
 
-@xroad.command(
-    u'update_xroad_organizations',
-    help='Updates harvested organizations\' metadata'
-)
+@xroad.command()
 @click.pass_context
-def update_xroad_organizations(ctx, config):
+def update_xroad_organizations(ctx):
+    'Updates harvested organizations\' metadata'
     flask_app = ctx.meta["flask_app"]
     with flask_app.test_request_context():
         utils.update_xroad_organization()
 
-@xroad.command(
-    u'fetch_errors',
-    help='Fetches error log from catalog lister'
-)
+
+@xroad.command()
 @click.pass_context
-def fetch_errors(ctx, config):
+def fetch_errors(ctx):
+    'Fetches error log from catalog lister'
     flask_app = ctx.meta["flask_app"]
     with flask_app.test_request_context():
         utils.fetch_errors()
 
-@xroad.command(
-    u'fetch_stats',
-    help='Fetches X-Road stats from catalog lister'
-)
+
+@xroad.command()
 @click.pass_context
 @click.option(u'--days', type=int)
-def fetch_stats(ctx, config, days):
-
+def fetch_stats(ctx, days):
+    'Fetches X-Road stats from catalog lister'
     flask_app = ctx.meta["flask_app"]
     with flask_app.test_request_context():
         utils.fetch_stats(days)
 
-@xroad.command(
-    u'fetch_service_list',
-    help='Fetches X-Road services from catalog lister'
-)
+
+@xroad.command()
 @click.pass_context
 @click.option(u'--days', type=int)
-def fetch_service_list(ctx, config, days):
-
+def fetch_service_list(ctx, days):
+    'Fetches X-Road services from catalog lister'
     flask_app = ctx.meta["flask_app"]
     with flask_app.test_request_context():
         utils.fetch_service_list(days)
+
+
+@xroad.command()
+@click.pass_context
+def fetch_heartbeat(ctx):
+    'Fetches X-Road catalog heartbeat'
+    flask_app = ctx.meta["flask_app"]
+    with flask_app.test_request_context():
+        utils.fetch_xroad_heartbeat()

--- a/ckanext/xroad_integration/model.py
+++ b/ckanext/xroad_integration/model.py
@@ -274,6 +274,33 @@ class XRoadBatchResult(Base, AsDictMixin):
         return results
 
 
+class XRoadHeartbeat(Base, AsDictMixin):
+    __tablename__ = 'xroad_heartbeat'
+
+    timestamp = Column(types.DateTime, primary_key=True, server_default=func.now())
+    success = Column(types.Boolean, nullable=False)
+
+    @classmethod
+    def create(cls, success):
+        xroad_heartbeat = cls(success=success)
+        model.Session.add(xroad_heartbeat)
+        model.repo.commit()
+
+    @classmethod
+    def get_latest(cls):
+        return (model.Session.query(cls)
+                .order_by(cls.timestamp.desc())
+                .first())
+
+    @classmethod
+    def get_between(cls, since, until):
+        return (model.Session.query(cls)
+                .filter(cls.timestamp >= since)
+                .filter(cls.timestamp <= until)
+                .order_by(cls.timestamp.asc())
+                .all())
+
+
 def init_table(engine):
     Base.metadata.create_all(engine)
     log.info("Table for xroad data is set-up")

--- a/ckanext/xroad_integration/plugin.py
+++ b/ckanext/xroad_integration/plugin.py
@@ -10,6 +10,7 @@ from ckanext.xroad_integration.auth import xroad_error_list
 
 import ckanext.xroad_integration.cli as cli
 
+
 class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IResourceController, inherit=True)
@@ -75,6 +76,9 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'xroad_service_list': action.xroad_service_list,
             'xroad_batch_result_create': action.xroad_batch_result_create,
             'xroad_latest_batch_results': action.xroad_latest_batch_results,
+            'fetch_xroad_heartbeat': action.fetch_xroad_heartbeat,
+            'xroad_heartbeat': action.xroad_heartbeat,
+            'xroad_heartbeat_history': action.xroad_heartbeat_history,
         }
 
     # IAuthFunctions
@@ -89,6 +93,8 @@ class Xroad_IntegrationPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'fetch_xroad_service_list': sysadmin,
             'xroad_service_list': sysadmin,
             'xroad_batch_result': sysadmin,
+            'fetch_xroad_heartbeat': sysadmin,
+            'xroad_heartbeat': sysadmin,
         }
 
     # IBlueprint

--- a/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
+++ b/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
@@ -27,6 +27,10 @@ def create_app(input_file):
     def getServiceStatistics(days=1):
         return json.dumps({'serviceStatisticsList': []})
 
+    @app.route('/heartbeat')
+    def heartbeat():
+        return 'OK'
+
     return app
 
 

--- a/ckanext/xroad_integration/utils.py
+++ b/ckanext/xroad_integration/utils.py
@@ -1,6 +1,7 @@
 from ckan.plugins.toolkit import get_action
 import json
 
+
 def init_db():
     import ckan.model as model
     from ckanext.xroad_integration.model import init_table
@@ -95,3 +96,14 @@ def latest_batch_run_results():
     response = get_action('xroad_latest_batch_results')({'ignore_auth': True}, {})
     return response['results']
 
+
+def fetch_xroad_heartbeat():
+    try:
+        result = get_action('fetch_xroad_heartbeat')({'ignore_auth': True}, {})
+
+        if result.get('success') is True:
+            print('Success:', result.get('heartbeat'))
+        else:
+            print('Error fetching heartbeat: %s', result.get('message', '(no message)'))
+    except Exception as e:
+        print('Error fetching heartbeat: \n', e)


### PR DESCRIPTION
- Added a new database table for X-Road catalog heartbeat logging
- Added actions `fetch_xroad_heartbeat`, `xroad_heartbeat` and `xroad_heartbeat_history` for updating and querying the table
  - Actual heartbeat fetch code moved here from ckanext-apicatalog_routes
- Added CLI command `xroad fetch-heartbeat` for calling the `fetch_xroad_heartbeat` action
- Fixed the other CLI command names to match api-catalog ansible
- Added heartbeat support to xroad_rest_mock