### PR TITLE
LIKA-441 remove unused fields from error list

### DIFF
--- a/ckanext/xroad_integration/templates/admin/xroad_errors.html
+++ b/ckanext/xroad_integration/templates/admin/xroad_errors.html
@@ -30,8 +30,8 @@
             {% for error in error_list.list_errors %}
                 <tr>
                     <td>{{ h.render_datetime(error.created) }}</td>
-                    <td>{{ error.xroad_instance }}.{{ error.member_class }}.{{ error.member_code }}.{{ error.subsystem_code }}</td>
-                    <td>{{ error.service_code }}.{{ error.service_version }}</td>
+                    <td>{{ error.xroadInstance }}.{{ error.memberClass }}.{{ error.memberCode }}.{{ error.subsystemCode }}</td>
+                    <td>{{ error.serviceCode }}.{{ error.serviceVersion }}</td>
                     <td>{{ error.message }}</td>
                     <td>{{ error.code }}</td>
                 </tr>

--- a/ckanext/xroad_integration/templates/admin/xroad_errors.html
+++ b/ckanext/xroad_integration/templates/admin/xroad_errors.html
@@ -22,7 +22,7 @@
                     <th style="width: 10%">{% trans %}Created{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Subsystem{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Service{% endtrans %}</th>
-                    <th style="width: 35%">{% trans %}Message{% endtrans %}</th>
+                    <th style="width: 65%">{% trans %}Message{% endtrans %}</th>
                     <th style="width: 5%">{% trans %}Code{% endtrans %}</th>
                 </tr>
             </thead>
@@ -30,8 +30,8 @@
             {% for error in error_list.list_errors %}
                 <tr>
                     <td>{{ h.render_datetime(error.created) }}</td>
-                    <td>{{ error.xroadInstance }}.{{ error.memberClass }}.{{ error.memberCode }}.{{ error.subsystemCode }}</td>
-                    <td>{{ error.serviceCode }}.{{ error.serviceVersion }}</td>
+                    <td>{{ error.xroad_instance }}.{{ error.member_class }}.{{ error.member_code }}.{{ error.subsystem_code }}</td>
+                    <td>{{ error.service_code }}.{{ error.service_version }}</td>
                     <td>{{ error.message }}</td>
                     <td>{{ error.code }}</td>
                 </tr>
@@ -53,7 +53,7 @@
                     <th style="width: 10%">{% trans %}Created{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Subsystem{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Service{% endtrans %}</th>
-                    <th style="width: 35%">{% trans %}Message{% endtrans %}</th>
+                    <th style="width: 65%">{% trans %}Message{% endtrans %}</th>
                     <th style="width: 5%">{% trans %}Code{% endtrans %}</th>
                 </tr>
             </thead>
@@ -76,7 +76,7 @@
                     <th style="width: 10%">{% trans %}Created{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Subsystem{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Service{% endtrans %}</th>
-                    <th style="width: 35%">{% trans %}Message{% endtrans %}</th>
+                    <th style="width: 65%">{% trans %}Message{% endtrans %}</th>
                     <th style="width: 5%">{% trans %}Code{% endtrans %}</th>
                 </tr>
             </thead>

--- a/ckanext/xroad_integration/templates/admin/xroad_errors.html
+++ b/ckanext/xroad_integration/templates/admin/xroad_errors.html
@@ -23,9 +23,6 @@
                     <th style="width: 10%">{% trans %}Subsystem{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Service{% endtrans %}</th>
                     <th style="width: 35%">{% trans %}Message{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Server code{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Security category code{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Group code{% endtrans %}</th>
                     <th style="width: 5%">{% trans %}Code{% endtrans %}</th>
                 </tr>
             </thead>
@@ -36,9 +33,6 @@
                     <td>{{ error.xroadInstance }}.{{ error.memberClass }}.{{ error.memberCode }}.{{ error.subsystemCode }}</td>
                     <td>{{ error.serviceCode }}.{{ error.serviceVersion }}</td>
                     <td>{{ error.message }}</td>
-                    <td>{{ error.serverCode }}</td>
-                    <td>{{ error.securityCategoryCode }}</td>
-                    <td>{{ error.groupCode }}</td>
                     <td>{{ error.code }}</td>
                 </tr>
             {% endfor %}
@@ -60,9 +54,6 @@
                     <th style="width: 10%">{% trans %}Subsystem{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Service{% endtrans %}</th>
                     <th style="width: 35%">{% trans %}Message{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Server code{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Security category code{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Group code{% endtrans %}</th>
                     <th style="width: 5%">{% trans %}Code{% endtrans %}</th>
                 </tr>
             </thead>
@@ -73,9 +64,6 @@
                     <td>{{ error.xroad_instance }}.{{ error.member_class }}.{{ error.member_code }}.{{ error.subsystem_code }}</td>
                     <td>{{ error.service_code }}.{{ error.service_version }}</td>
                     <td>{{ error.message }}</td>
-                    <td>{{ error.server_code }}</td>
-                    <td>{{ error.security_category_code }}</td>
-                    <td>{{ error.group_code }}</td>
                     <td>{{ error.code }}</td>
                 </tr>
             {% endfor %}
@@ -89,9 +77,6 @@
                     <th style="width: 10%">{% trans %}Subsystem{% endtrans %}</th>
                     <th style="width: 10%">{% trans %}Service{% endtrans %}</th>
                     <th style="width: 35%">{% trans %}Message{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Server code{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Security category code{% endtrans %}</th>
-                    <th style="width: 10%">{% trans %}Group code{% endtrans %}</th>
                     <th style="width: 5%">{% trans %}Code{% endtrans %}</th>
                 </tr>
             </thead>
@@ -102,9 +87,6 @@
                     <td>{{ error.xroad_instance }}.{{ error.member_class }}.{{ error.member_code }}.{{ error.subsystem_code }}</td>
                     <td>{{ error.service_code }}.{{ error.service_version }}</td>
                     <td>{{ error.message }}</td>
-                    <td>{{ error.server_code }}</td>
-                    <td>{{ error.security_category_code }}</td>
-                    <td>{{ error.group_code }}</td>
                     <td>{{ error.code }}</td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
LIKA 441: removed unused/empty fields group_code, server_code and security_category_code from error list.