### PR TITLE
LIKA-444: replace get errors

### DIFF
--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -432,7 +432,6 @@ def fetch_xroad_errors(context, data_dict):
 
     for harvest_source in harvest_sources:
         source_title = harvest_source.get('title', '')
-        source_url = harvest_source.get('url', '')
 
         if "since" in data_dict:
             since = data_dict.get('since')

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -441,7 +441,8 @@ def fetch_xroad_errors(context, data_dict):
         days = DEFAULT_LIST_ERRORS_HISTORY_IN_DAYS
         fetch_since = datetime.datetime.strptime(since, "%Y-%m-%d")
         max_fetch_date_in_past = (datetime.datetime.today() -
-                                  relativedelta.relativedelta(days=DEFAULT_LIST_ERRORS_HISTORY_IN_DAYS)).replace(hour=0, minute=0, second=0, microsecond=0)
+                                  relativedelta.relativedelta(days=DEFAULT_LIST_ERRORS_HISTORY_IN_DAYS))\
+            .replace(hour=0, minute=0, second=0, microsecond=0)
         last_fetched = max_fetch_date_in_past
 
         if fetch_since > max_fetch_date_in_past:

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -831,7 +831,7 @@ def fetch_distinct_service_stats(context, data_dict):
         statistics_data = xroad_catalog_query('getDistinctServiceStatistics', [str(days)]).json()
 
         if statistics_data is None:
-            log.warn("Calling geftDistinctServiceStatistics failed!")
+            log.warn("Calling getDistinctServiceStatistics failed!")
             return {'success': False, 'message': 'Calling getDistinctServiceStatistics failed!'}
         elif 'distinctServiceStatisticsList' not in statistics_data:
             return {'success': False, 'message': 'Calling getDistinctServiceStatistics returned message: "{}"'


### PR DESCRIPTION
# Description
Update the xroad-integration to call ListErrors REST endpoint instead of GetErrors SOAP endpoint

## Jira ticket reference: [LIKA-444](https://jira.dvv.fi/browse/LIKA-444)

## What has changed:
* Content of the method fetch_xroad_errors

## Checklist  

- [ ] Contains schema changes.
- [ ] Schema changes require migration of existing data.
- [ ] Contains migration script for existing data.
- [ ] Changes should be covered by tests.
- [ ] Changes are covered by tests.

### Does this have a design impact ?
- [ ] Yes 
- [x] No