### PR TITLE
Add unit test for rest services

### DIFF
--- a/ckanext/xroad_integration/tests/fixtures.py
+++ b/ckanext/xroad_integration/tests/fixtures.py
@@ -64,7 +64,7 @@ def xroad_rest_mocks():
 
 @pytest.fixture
 def xroad_database_setup():
-    from ckanext.xroad_integration.utils import init_db, drop_db
+    from ckanext.xroad_integration.utils import init_db
 
     init_db()
 

--- a/ckanext/xroad_integration/tests/fixtures.py
+++ b/ckanext/xroad_integration/tests/fixtures.py
@@ -68,10 +68,6 @@ def xroad_database_setup():
 
     init_db()
 
-    yield
-
-    drop_db()
-
 
 def xroad_rest_adapter_url(adapter_name):
     return 'http://{host}:{port}/rest-adapter-service'.format(**XROAD_REST_ADAPTERS[adapter_name])

--- a/ckanext/xroad_integration/tests/fixtures.py
+++ b/ckanext/xroad_integration/tests/fixtures.py
@@ -1,0 +1,81 @@
+from multiprocessing import Process
+
+import os
+import pytest
+
+from ckanext.xroad_integration.tests.xroad_mock import xroad_rest_adapter_mock as adapter_mock
+from ckanext.xroad_integration.tests.xroad_mock import xroad_rest_mock as rest_mock
+
+XROAD_REST_ADAPTERS = {
+    'base': {'host': '127.0.0.1', 'port': 9091, 'content': 'xroad-catalog-mock-responses/test_listmembers.json'},
+    'delete_one_of_each': {'host': '127.0.0.1', 'port': 9092,
+                           'content': 'xroad-catalog-mock-responses/test_delete_listmembers.json'},
+    'get_organizations': {'host': '127.0.0.1', 'port': 9093,
+                          'content': 'xroad-catalog-mock-responses/test_getorganizations.json'}
+}
+
+XROAD_REST_SERVICES = {
+    'heartbeat': {'host': '127.0.0.1', 'port': 9191, 'content': 'xroad-catalog-mock-responses/test_heartbeat.json'}
+}
+
+
+@pytest.fixture(scope='module')
+def xroad_rest_adapter_mocks():
+    procs = []
+
+    for adapter in XROAD_REST_ADAPTERS.values():
+        data_path = os.path.join(os.path.dirname(__file__), adapter['content'])
+        xroad_rest_adapter_mock_app = adapter_mock.instance(data_path)
+
+        mock_proc = Process(target=xroad_rest_adapter_mock_app.run, kwargs={
+            'host': adapter['host'],
+            'port': adapter['port']})
+        mock_proc.start()
+        procs.append(mock_proc)
+
+    yield XROAD_REST_ADAPTERS.keys()
+
+    for mock_proc in procs:
+        mock_proc.terminate()
+        mock_proc.join()
+
+
+@pytest.fixture(scope='module')
+def xroad_rest_mocks():
+    procs = []
+
+    for service in XROAD_REST_SERVICES.values():
+        data_path = os.path.join(os.path.dirname(__file__), service['content'])
+        xroad_rest_mock_app = rest_mock.create_app(data_path)
+
+        mock_proc = Process(target=xroad_rest_mock_app.run, kwargs={
+            'host': service['host'],
+            'port': service['port']
+        })
+        mock_proc.start()
+        procs.append(mock_proc)
+
+    yield XROAD_REST_SERVICES.keys()
+
+    for mock_proc in procs:
+        mock_proc.terminate()
+        mock_proc.join()
+
+
+@pytest.fixture
+def xroad_database_setup():
+    from ckanext.xroad_integration.utils import init_db, drop_db
+
+    init_db()
+
+    yield
+
+    drop_db()
+
+
+def xroad_rest_adapter_url(adapter_name):
+    return 'http://{host}:{port}/rest-adapter-service'.format(**XROAD_REST_ADAPTERS[adapter_name])
+
+
+def xroad_rest_service_url(service_name):
+    return 'http://{host}:{port}/'.format(**XROAD_REST_SERVICES[service_name])

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -1,90 +1,13 @@
 """Tests for plugin.py."""
 from ckan import model
 from ckan.plugins import toolkit
-from ckanext.xroad_integration.tests.xroad_mock import xroad_rest_adapter_mock as adapter_mock
-from ckanext.xroad_integration.tests.xroad_mock import xroad_rest_mock as rest_mock
 import pytest
 import json
-import os
-from multiprocessing import Process
 from ckanext.xroad_integration.harvesters.xroad_harvester import XRoadHarvesterPlugin
 from ckantoolkit.tests.helpers import call_action
 from ckanext.harvest.tests.lib import run_harvest
 
-
-XROAD_REST_ADAPTERS = {
-        'base': {'host': '127.0.0.1', 'port': 9091, 'content': 'xroad-catalog-mock-responses/test_listmembers.json'},
-        'delete_one_of_each': {'host': '127.0.0.1', 'port': 9092,
-                               'content': 'xroad-catalog-mock-responses/test_delete_listmembers.json'},
-        'get_organizations': {'host': '127.0.0.1', 'port': 9093,
-                              'content': 'xroad-catalog-mock-responses/test_getorganizations.json'}
-        }
-
-XROAD_REST_SERVICES = {
-    'heartbeat': {'host': '127.0.0.1', 'port': 9191, 'content': 'xroad-catalog-mock-responses/test_heartbeat.json'}
-}
-
-
-def xroad_rest_adapter_url(adapter_name):
-    return 'http://{host}:{port}/rest-adapter-service'.format(**XROAD_REST_ADAPTERS[adapter_name])
-
-
-def xroad_rest_service_url(service_name):
-    return 'http://{host}:{port}/'.format(**XROAD_REST_SERVICES[service_name])
-
-
-@pytest.fixture(scope='module')
-def xroad_rest_adapter_mocks():
-    procs = []
-
-    for adapter in XROAD_REST_ADAPTERS.values():
-        data_path = os.path.join(os.path.dirname(__file__), adapter['content'])
-        xroad_rest_adapter_mock_app = adapter_mock.instance(data_path)
-
-        mock_proc = Process(target=xroad_rest_adapter_mock_app.run, kwargs={
-            'host': adapter['host'],
-            'port': adapter['port']})
-        mock_proc.start()
-        procs.append(mock_proc)
-
-    yield XROAD_REST_ADAPTERS.keys()
-
-    for mock_proc in procs:
-        mock_proc.terminate()
-        mock_proc.join()
-
-
-@pytest.fixture(scope='module')
-def xroad_rest_mocks():
-    procs = []
-
-    for service in XROAD_REST_SERVICES.values():
-        data_path = os.path.join(os.path.dirname(__file__), service['content'])
-        xroad_rest_mock_app = rest_mock.create_app(data_path)
-
-        mock_proc = Process(target=xroad_rest_mock_app.run, kwargs={
-            'host': service['host'],
-            'port': service['port']
-        })
-        mock_proc.start()
-        procs.append(mock_proc)
-
-    yield XROAD_REST_SERVICES.keys()
-
-    for mock_proc in procs:
-        mock_proc.terminate()
-        mock_proc.join()
-
-
-@pytest.fixture(scope='module')
-def xroad_database_setup():
-    from ckanext.xroad_integration.utils import init_db, drop_db
-
-    init_db()
-
-    yield
-
-    drop_db()
+from .fixtures import xroad_rest_service_url, xroad_rest_adapter_url
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
@@ -176,9 +99,10 @@ def test_xroad_errors(xroad_rest_adapter_mocks, xroad_database_setup):
     call_action('xroad_error_list')
 
 
-@pytest.mark.usefixtures('clean_db')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup', 'xroad_database_setup')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('heartbeat'))
-def test_xroad_heartbeat(xroad_rest_mocks, xroad_database_setup):
+def test_xroad_heartbeat(xroad_rest_mocks):
     result = call_action('fetch_xroad_heartbeat')
     assert result['heartbeat'] is True
     assert result['success'] is True
+

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -175,6 +175,8 @@ def test_xroad_errors(xroad_rest_adapter_mocks, xroad_database_setup):
     call_action('fetch_xroad_errors')
     call_action('xroad_error_list')
 
+
+@pytest.mark.usefixtures('clean_db')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('heartbeat'))
 def test_xroad_heartbeat(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_heartbeat')

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -105,4 +105,3 @@ def test_xroad_heartbeat(xroad_rest_mocks):
     result = call_action('fetch_xroad_heartbeat')
     assert result['heartbeat'] is True
     assert result['success'] is True
-

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -24,11 +24,14 @@ XROAD_REST_SERVICES = {
     'heartbeat': {'host': '127.0.0.1', 'port': 9191, 'content': 'xroad-catalog-mock-responses/test_heartbeat.json'}
 }
 
+
 def xroad_rest_adapter_url(adapter_name):
     return 'http://{host}:{port}/rest-adapter-service'.format(**XROAD_REST_ADAPTERS[adapter_name])
 
+
 def xroad_rest_service_url(service_name):
     return 'http://{host}:{port}/'.format(**XROAD_REST_SERVICES[service_name])
+
 
 @pytest.fixture(scope='module')
 def xroad_rest_adapter_mocks():
@@ -71,6 +74,7 @@ def xroad_rest_mocks():
     for mock_proc in procs:
         mock_proc.terminate()
         mock_proc.join()
+
 
 @pytest.fixture(scope='module')
 def xroad_database_setup():
@@ -174,5 +178,5 @@ def test_xroad_errors(xroad_rest_adapter_mocks, xroad_database_setup):
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('heartbeat'))
 def test_xroad_heartbeat(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_heartbeat')
-    assert result['heartbeat'] == True
-    assert result['success'] == True
+    assert result['heartbeat'] is True
+    assert result['success'] is True

--- a/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
+++ b/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
@@ -29,7 +29,7 @@ def create_app(input_file):
 
     @app.route('/heartbeat')
     def heartbeat():
-        return 'OK'
+        return mock_data
 
     return app
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,4 +2,5 @@
 
 pytest_plugins = [
     u'ckanext.harvest.tests.fixtures',
+    u'ckanext.xroad_integration.tests.fixtures'
 ]

--- a/test.ini
+++ b/test.ini
@@ -15,8 +15,8 @@ use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
 # tests here.
 ckan.locale_default = fi
 ckan.plugins = apicatalog_scheming scheming_datasets scheming_organizations fluent harvest xroad_harvester xroad_integration
-ckanext.xroad_integration.xroad_catalog_address = "localhost"
-ckanext.xroad_integration.xroad_client_id = "someid"
+ckanext.xroad_integration.xroad_catalog_address = http://localhost
+ckanext.xroad_integration.xroad_client_id = someid
 ckanext.xroad_integration.unknown_service_link_url = https://example.com
 
 


### PR DESCRIPTION
Adds unit test for rest services in general and specifically for heartbeat. Moves fixtures to its own file for allowing them to be called via pytest decorators.