### PR TITLE
LIKA-462: handle no content responses

### DIFF
--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -130,7 +130,7 @@ def fetch_errors(ctx, start_date, end_date):
               help="""Optional, unless end-date is given in which case start-date is also required.
               If not given yesterday is used as a default.""",)
 @click.option(u'-e', u'--end-date', type=click.DateTime(formats=["%Y-%m-%d"]),
-              help="""Optional. If not given current date is used as a default""",)
+              help="""Optional. If not given yesterday date is used as a default""",)
 def fetch_stats(ctx, start_date, end_date):
     try:
         validate_date_range(start_date, end_date)
@@ -166,7 +166,7 @@ def fetch_stats(ctx, start_date, end_date):
               help="""Optional, unless end-date is given in which case start-date is also required.
               If not given yesterday is used as a default.""",)
 @click.option(u'-e', u'--end-date', type=click.DateTime(formats=["%Y-%m-%d"]),
-              help="""Optional. If not given current date is used as a default""",)
+              help="""Optional. If not given yesterday date is used as a default""",)
 def fetch_distinct_service_stats(ctx, start_date, end_date):
     'Fetches X-Road distinct service stats from catalog lister'
     try:
@@ -204,7 +204,7 @@ def fetch_distinct_service_stats(ctx, start_date, end_date):
               help="""Optional, unless end-date is given in which case start-date is also required.
               If not given yesterday is used as a default.""",)
 @click.option(u'-e', u'--end-date', type=click.DateTime(formats=["%Y-%m-%d"]),
-              help="""Optional. If not given current date is used as a default""",)
+              help="""Optional. If not given yesterday date is used as a default""",)
 def fetch_service_list(ctx, start_date, end_date):
     'Fetches X-Road services from catalog lister'
     try:

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -118,8 +118,7 @@ def fetch_errors(ctx, start_date, end_date):
                                                                         'message': results.get('message')})
 
         if success:
-            for result in results.get('results', []):
-                click.secho(result['message'], fg="green")
+            click.secho(results['message'], fg="green")
 
         else:
             click.secho(results['message'], fg="red")

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -381,7 +381,6 @@ def fetch_xroad_errors(context, data_dict):
     errors = []
     error_count = 0
 
-
     start_date = string_to_date(data_dict.get('start_date'))
     end_date = string_to_date(data_dict.get('end_date'))
 
@@ -594,7 +593,7 @@ def fetch_xroad_service_list(context, data_dict):
 
             if not all((instance, member_class, member_code, server_code, address)):
                 log.warning('Security server %s.%s (%s) is missing required information, skipping.',
-                         member_class, member_code, server_code)
+                            member_class, member_code, server_code)
                 continue
 
             XRoadServiceListSecurityServer.create(service_list.id, instance, member_class, member_code,

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -360,7 +360,7 @@ def set_date_range_defaults(start_date, end_date):
 
     yesterday = datetime.datetime.now() - relativedelta.relativedelta(days=+1)
     start_date = start_date or yesterday
-    end_date = end_date or yesterday
+    end_date = end_date or datetime.datetime.now()
 
     return start_date, end_date
 

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -354,13 +354,22 @@ def date_to_string(date):
     return datetime.datetime.strftime(date, "%Y-%m-%d")
 
 
-def set_date_range_defaults(start_date, end_date):
+def set_date_range_defaults(start_date: datetime.datetime = None, end_date: datetime.datetime = None,
+                            is_range: bool = False):
+    """
+    If is_range is True, returns current date as default, otherwise yesterday.
+    """
+
     if end_date and not start_date:
         raise ValueError("Please give start date to go with the end date")
 
     yesterday = datetime.datetime.now() - relativedelta.relativedelta(days=+1)
     start_date = start_date or yesterday
-    end_date = end_date or datetime.datetime.now()
+
+    if is_range is True:
+        end_date = end_date or datetime.datetime.now()
+    else:
+        end_date = end_date or yesterday
 
     return start_date, end_date
 
@@ -385,7 +394,7 @@ def fetch_xroad_errors(context, data_dict):
     end_date = string_to_date(data_dict.get('end_date'))
 
     try:
-        start_date, end_date = set_date_range_defaults(start_date, end_date)
+        start_date, end_date = set_date_range_defaults(start_date, end_date, is_range=True)
         validate_date_range(start_date, end_date)
     except ValueError as e:
         return {'success': False, 'message': str(e)}
@@ -551,7 +560,7 @@ def fetch_xroad_service_list(context, data_dict):
     end_date = string_to_date(data_dict.get('end_date'))
 
     try:
-        start_date, end_date = set_date_range_defaults(start_date, end_date)
+        start_date, end_date = set_date_range_defaults(start_date, end_date, is_range=False)
         validate_date_range(start_date, end_date)
     except ValueError as e:
         return {'success': False, 'message': str(e)}
@@ -802,7 +811,7 @@ def fetch_xroad_stats(context, data_dict):
     end_date = string_to_date(data_dict.get('end_date'))
 
     try:
-        start_date, end_date = set_date_range_defaults(start_date, end_date)
+        start_date, end_date = set_date_range_defaults(start_date, end_date, is_range=False)
         validate_date_range(start_date, end_date)
     except ValueError as e:
         return {'success': False, 'message': str(e)}
@@ -856,7 +865,7 @@ def fetch_distinct_service_stats(context, data_dict):
     end_date = string_to_date(data_dict.get('end_date'))
 
     try:
-        start_date, end_date = set_date_range_defaults(start_date, end_date)
+        start_date, end_date = set_date_range_defaults(start_date, end_date, is_range=False)
         validate_date_range(start_date, end_date)
     except ValueError as e:
         return {'success': False, 'message': str(e)}

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -378,85 +378,82 @@ def validate_date_range(start_date, end_date):
 
 def fetch_xroad_errors(context, data_dict):
     toolkit.check_access('fetch_xroad_errors', context)
-    results = []
     errors = []
-
     error_count = 0
-    harvest_sources = xroad_harvest_sources(context)
 
-    for harvest_source in harvest_sources:
-        source_title = harvest_source.get('title', '')
 
-        start_date = string_to_date(data_dict.get('start_date'))
-        end_date = string_to_date(data_dict.get('end_date'))
+    start_date = string_to_date(data_dict.get('start_date'))
+    end_date = string_to_date(data_dict.get('end_date'))
 
-        try:
-            start_date, end_date = set_date_range_defaults(start_date, end_date)
-            validate_date_range(start_date, end_date)
-        except ValueError as e:
-            return {'success': False, 'message': str(e)}
+    try:
+        start_date, end_date = set_date_range_defaults(start_date, end_date)
+        validate_date_range(start_date, end_date)
+    except ValueError as e:
+        return {'success': False, 'message': str(e)}
 
-        queryparams = {
-            'startDate': date_to_string(start_date),
-            'endDate': date_to_string(end_date)
-        }
+    queryparams = {
+        'startDate': date_to_string(start_date),
+        'endDate': date_to_string(end_date)
+    }
 
-        page = 0
-        if "page" in data_dict and data_dict.get('page') is not None:
-            page = data_dict.get('page')
-        limit = DEFAULT_LIST_ERRORS_PAGE_LIMIT
-        if "limit" in data_dict and data_dict.get('limit') is not None:
-            limit = data_dict.get('limit')
+    page = 0
+    if "page" in data_dict and data_dict.get('page') is not None:
+        page = data_dict.get('page')
+    limit = DEFAULT_LIST_ERRORS_PAGE_LIMIT
+    if "limit" in data_dict and data_dict.get('limit') is not None:
+        limit = data_dict.get('limit')
 
-        log.info("Fetching errors from %s to %s for %s" % (start_date, end_date, source_title))
+    log.info("Fetching errors from %s to %s" % (start_date, end_date))
 
-        organizations = toolkit.get_action('organization_list')(context, {})
+    organizations = toolkit.get_action('organization_list')(context, {})
+    log.warning(organizations)
+    try:
+        for org_name in organizations:
+            log.warning(org_name)
+            organization = toolkit.get_action('organization_show')(context, {'id': org_name})
+            if not (organization.get('xroad_instance') and organization.get('xroad_memberclass') and
+                    organization.get('xroad_membercode')):
+                log.warning('Invalid xroad organization: %s, not fetching errors for it', organization['id'])
+                continue
 
-        try:
-            for org_name in organizations:
-                organization = toolkit.get_action('organization_show')(context, {'id': org_name})
-                if not (organization.get('xroad_instance') and organization.get('xroad_memberclass') and
-                        organization.get('xroad_membercode')):
-                    log.warning('Invalid xroad organization: %s, not fetching errors for it', organization['id'])
-                    continue
+            params = [organization.get('xroad_instance'),
+                      organization.get('xroad_memberclass'),
+                      organization.get('xroad_membercode')]
+            pagination = {"page": str(page), "limit": str(limit)}
+            try:
+                no_of_pages, added_errors_count = _fetch_error_page(params=params, queryparams=queryparams,
+                                                                    pagination=pagination)
+                error_count += added_errors_count
+            except ValueError:
+                return {'success': False, 'message': 'Calling listErrors failed!'}
 
-                params = [organization.get('xroad_instance'),
-                          organization.get('xroad_memberclass'),
-                          organization.get('xroad_membercode')]
-                pagination = {"page": str(page), "limit": str(limit)}
+            for page_no in range(1, no_of_pages):
                 try:
-                    no_of_pages, added_errors_count = _fetch_error_page(params=params, queryparams=queryparams,
-                                                                        pagination=pagination)
-                    error_count += added_errors_count
-                except ValueError:
-                    return {'success': False, 'message': 'Calling listErrors failed!'}
-
-                for page_no in range(1, no_of_pages):
+                    pagination = {"page": str(page_no), "limit": str(limit)}
                     try:
-                        pagination = {"page": str(page_no), "limit": str(limit)}
-                        try:
-                            no_of_pages, added_errors_count = _fetch_error_page(params=params, queryparams=queryparams,
-                                                                                pagination=pagination)
-                            error_count += added_errors_count
-                        except ValueError:
-                            return {'success': False, 'message': 'Calling listErrors failed!'}
+                        no_of_pages, added_errors_count = _fetch_error_page(params=params, queryparams=queryparams,
+                                                                            pagination=pagination)
+                        error_count += added_errors_count
+                    except ValueError:
+                        return {'success': False, 'message': 'Calling listErrors failed!'}
 
-                    except ConnectionError as e:
-                        log.warning("Calling listErrors failed!")
-                        log.info(e)
-                        return {"success": False, "message": "Fetching errors failed."}
+                except ConnectionError as e:
+                    log.warning("Calling listErrors failed!")
+                    log.info(e)
+                    return {"success": False, "message": "Fetching errors failed."}
 
-        except ConnectionError as e:
-            log.warning("Calling listErrors failed!")
-            log.info(e)
-            return {"success": False, "message": "Fetching errors failed."}
+    except ConnectionError as e:
+        log.warning("Calling listErrors failed!")
+        log.info(e)
+        return {"success": False, "message": "Fetching errors failed."}
 
-    results.append({"message": "%d errors stored to database." % error_count})
+    log.warning(error_count)
+    results = {"message": "%d errors stored to database." % error_count}
     if errors:
         return {"success": False, "message": ", ".join(errors)}
     else:
         return {"success": True, "results": results,
-                "message": 'Fetched errors for {} harvest sources'.format(len(results))}
+                "message": 'Fetched errors for xroad'}
 
 
 def _fetch_error_page(params, queryparams, pagination) -> (int, int):

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -119,9 +119,14 @@ def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
     "start_date, end_date, exp",
     [
         (
+          None,
+          None,
+          'Services from 2022-01-06 to 2022-01-07 stored in database.'
+        ),
+        (
             "2022-01-01",
             None,
-            'Services from 2022-01-01 to 2022-01-06 stored in database.'
+            'Services from 2022-01-01 to 2022-01-07 stored in database.'
         ),
         (
             None,
@@ -172,9 +177,14 @@ def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
     "start_date, end_date, exp",
     [
         (
+          None,
+          None,
+          'Statistics from 2022-01-06 to 2022-01-07 stored in database.'
+        ),
+        (
             "2022-01-01",
             None,
-            'Statistics from 2022-01-01 to 2022-01-06 stored in database.'
+            'Statistics from 2022-01-01 to 2022-01-07 stored in database.'
         ),
         (
             None,
@@ -224,9 +234,14 @@ def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_databas
     "start_date, end_date, exp",
     [
         (
+          None,
+          None,
+          "Distinct service statistics from 2022-01-06 to 2022-01-07 stored in database."
+        ),
+        (
             "2022-01-01",
             None,
-            "Distinct service statistics from 2022-01-01 to 2022-01-06 stored in database."
+            "Distinct service statistics from 2022-01-01 to 2022-01-07 stored in database."
         ),
         (
             None,

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -104,7 +104,7 @@ def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
     sl = model.Session.query(XRoadServiceList).all()
     assert len(sl) == 1
     sl = sl[0].as_dict_full()
-    assert result['message'] == 'Services from 2022-01-01 to 2022-01-02 stored in database.'
+    assert result['message'] == 'Services from 2022-01-01 to 2022-01-01 stored in database.'
     assert len(sl['security_servers']) == 3
     org = sl.get("security_servers")[0]
     assert org["server_code"] == "Commercial"
@@ -121,12 +121,12 @@ def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
         (
           None,
           None,
-          'Services from 2022-01-06 to 2022-01-07 stored in database.'
+          'Services from 2022-01-06 to 2022-01-06 stored in database.'
         ),
         (
             "2022-01-01",
             None,
-            'Services from 2022-01-01 to 2022-01-07 stored in database.'
+            'Services from 2022-01-01 to 2022-01-06 stored in database.'
         ),
         (
             None,
@@ -179,12 +179,12 @@ def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
         (
           None,
           None,
-          'Statistics from 2022-01-06 to 2022-01-07 stored in database.'
+          'Statistics from 2022-01-06 to 2022-01-06 stored in database.'
         ),
         (
             "2022-01-01",
             None,
-            'Statistics from 2022-01-01 to 2022-01-07 stored in database.'
+            'Statistics from 2022-01-01 to 2022-01-06 stored in database.'
         ),
         (
             None,
@@ -236,12 +236,12 @@ def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_databas
         (
           None,
           None,
-          "Distinct service statistics from 2022-01-06 to 2022-01-07 stored in database."
+          "Distinct service statistics from 2022-01-06 to 2022-01-06 stored in database."
         ),
         (
             "2022-01-01",
             None,
-            "Distinct service statistics from 2022-01-01 to 2022-01-07 stored in database."
+            "Distinct service statistics from 2022-01-01 to 2022-01-06 stored in database."
         ),
         (
             None,

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -104,7 +104,7 @@ def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
     sl = model.Session.query(XRoadServiceList).all()
     assert len(sl) == 1
     sl = sl[0].as_dict_full()
-    assert result['message'] == 'Services from 2022-01-01 to 2022-01-01 stored in database.'
+    assert result['message'] == 'Services from 2022-01-01 to 2022-01-02 stored in database.'
     assert len(sl['security_servers']) == 3
     org = sl.get("security_servers")[0]
     assert org["server_code"] == "Commercial"
@@ -165,7 +165,7 @@ def test_fetch_xroad_service_list_with_date_ranges(xroad_rest_mocks,
 def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_stats')
     stats = model.Session.query(XRoadStat).first()
-    assert result['message'] == 'Statistics from 2022-01-01 to 2022-01-01 stored in database.'
+    assert result['message'] == 'Statistics from 2022-01-01 to 2022-01-02 stored in database.'
     assert stats.date == datetime(2022, 1, 1, 0, 0)
     assert stats.soap_service_count == 1
     assert stats.rest_service_count == 1
@@ -224,7 +224,7 @@ def test_fetch_xroad_service_statistics_with_date_ranges(xroad_rest_mocks,
 def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_distinct_service_stats')
     stats = model.Session.query(XRoadDistinctServiceStat).first()
-    assert result['message'] == 'Distinct service statistics from 2022-01-01 to 2022-01-01 stored in database.'
+    assert result['message'] == 'Distinct service statistics from 2022-01-01 to 2022-01-02 stored in database.'
     assert stats.date == datetime(2022, 1, 1, 0, 0)
     assert stats.distinct_service_count == 1
 

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -165,7 +165,7 @@ def test_fetch_xroad_service_list_with_date_ranges(xroad_rest_mocks,
 def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_stats')
     stats = model.Session.query(XRoadStat).first()
-    assert result['message'] == 'Statistics from 2022-01-01 to 2022-01-02 stored in database.'
+    assert result['message'] == 'Statistics from 2022-01-01 to 2022-01-01 stored in database.'
     assert stats.date == datetime(2022, 1, 1, 0, 0)
     assert stats.soap_service_count == 1
     assert stats.rest_service_count == 1
@@ -224,7 +224,7 @@ def test_fetch_xroad_service_statistics_with_date_ranges(xroad_rest_mocks,
 def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_distinct_service_stats')
     stats = model.Session.query(XRoadDistinctServiceStat).first()
-    assert result['message'] == 'Distinct service statistics from 2022-01-01 to 2022-01-02 stored in database.'
+    assert result['message'] == 'Distinct service statistics from 2022-01-01 to 2022-01-01 stored in database.'
     assert stats.date == datetime(2022, 1, 1, 0, 0)
     assert stats.distinct_service_count == 1
 

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -81,8 +81,8 @@ def test_xroad_errors(xroad_rest_adapter_mocks, xroad_rest_mocks, xroad_database
     run_harvest(url=xroad_rest_adapter_url('base'), harvester=harvester)
 
     result = call_action('fetch_xroad_errors', start_date="2023-01-01", end_date="2023-01-05", limit=1)
-    assert result['message'] == 'Fetched errors for 1 harvest sources'
-    assert result['results'][0]['message'] == '12 errors stored to database.'
+    assert result['message'] == 'Fetched errors for xroad'
+    assert result['results']['message'] == '12 errors stored to database.'
 
     db_entry_count = model.Session.query(XRoadError).count()
     assert db_entry_count == 12

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest-ckan
 pytest-cov
+types-requests


### PR DESCRIPTION
Fetching errors for subsystem might return no content response, the implementation should not fail on this.
Removes parsing harvester information from fetch_errors api, as it does not use any of it except the name.
Fixes default dateranges and updates tests for them.