### PR TITLE
LIKA-460: Fix cli user handling in update_xroad_organizations

### DIFF
--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -79,7 +79,7 @@ def update_xroad_organizations(ctx):
     with flask_app.test_request_context():
         try:
             toolkit.g.user = _admin_user()['name']
-            context = {'ignore_auth': True, 'user': toolkit.g.user }
+            context = {'ignore_auth': True, 'user': toolkit.g.user}
             result = get_action('update_xroad_organizations')(context, {})
         except Exception as e:
             result = {'success': False, 'message': 'Exception: {}'.format(e)}

--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -78,7 +78,9 @@ def update_xroad_organizations(ctx):
     flask_app = ctx.meta["flask_app"]
     with flask_app.test_request_context():
         try:
-            result = get_action('update_xroad_organizations')({'ignore_auth': True}, {})
+            toolkit.g.user = _admin_user()['name']
+            context = {'ignore_auth': True, 'user': toolkit.g.user }
+            result = get_action('update_xroad_organizations')(context, {})
         except Exception as e:
             result = {'success': False, 'message': 'Exception: {}'.format(e)}
 
@@ -316,3 +318,9 @@ def send_latest_batch_run_results_email(dryrun):
 
     if dryrun:
         print(msg)
+
+
+def _admin_user():
+    from ckan import model
+    context = {"model": model, "session": model.Session, "ignore_auth": True}
+    return toolkit.get_action("get_site_user")(context, {})


### PR DESCRIPTION
- `update_xroad_organizations` handling requires both `toolkit.g.user` and `context["user"]` to be set to a value. Set them to site user.