### PR TITLE
LIKA-592: fix harvester

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
           sed -i -e 's/#ckan.plugins/ckan.plugins/' test.ini
           
           ckan -c test.ini db init
-          ckan -c test.ini harvester initdb
+          ckan -c test.ini db upgrade -p harvest
           ckan -c test.ini xroad init-db
           
           # Disable plugins in test.ini

--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -360,7 +360,7 @@ class XRoadHarvesterPlugin(HarvesterBase):
                 'name': name,
                 'xroad_servicecode': service.service_code,
                 'xroad_serviceversion': service.service_version,
-                'xroad_service_type': service.service_type,
+                # TODO: use data from xroad catalog 'xroad_service_type': service.service_type,
                 'harvested_from_xroad': True,
                 'access_restriction_level': 'public'
             }

--- a/ckanext/xroad_integration/harvesters/xroad_types.py
+++ b/ckanext/xroad_integration/harvesters/xroad_types.py
@@ -48,7 +48,7 @@ class Service(Base):
     changed: datetime
     fetched: datetime
     service_version: Optional[str] = field(default=None)
-    service_type: Optional[str] = field(default=None)
+    serviceType: Optional[str] = field(default=None)
     wsdl: Optional[ServiceDescription] = field(default=None)
     openapi: Optional[ServiceDescription] = field(default=None)
     removed: Optional[datetime] = field(default=None)

--- a/ckanext/xroad_integration/harvesters/xroad_types_utils.py
+++ b/ckanext/xroad_integration/harvesters/xroad_types_utils.py
@@ -47,7 +47,7 @@ class Base(object):
     @classmethod
     def deserialize(cls, data):
         obj = pickle.loads(base64.decodebytes(data.encode('utf-8')))
-        if type(obj) != cls:
+        if not isinstance(obj, cls):
             raise ValueError(f'Deserialized data describes a {type(obj)}, expected {cls}')
         return obj
 

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -17,8 +17,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 def test_base(xroad_rest_adapter_mocks):
 
     results = run_harvest(
@@ -47,8 +46,7 @@ def test_base(xroad_rest_adapter_mocks):
     assert len(results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources']) == 4
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 def test_base_twice(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     url = xroad_rest_adapter_url('base')
@@ -57,9 +55,7 @@ def test_base_twice(xroad_rest_adapter_mocks):
     run_harvest(url=url, harvester=harvester, config=config)
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
-                                         'xroad_harvester xroad_integration')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 def test_delete(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     run_harvest(url=xroad_rest_adapter_url('base'), harvester=harvester)
@@ -94,8 +90,7 @@ def test_delete(xroad_rest_adapter_mocks):
     assert should_not_be_removed_org.get('xroad_removed') is False
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 def test_listmembers_on_error(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     results = run_harvest(url=xroad_rest_adapter_url('listmembers_error'), harvester=harvester)
@@ -107,9 +102,7 @@ def test_listmembers_on_error(xroad_rest_adapter_mocks):
     assert "There was an error on xroad catalog" in harvest_report['gather_errors'][0]['message']
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
-                                         'xroad_harvester xroad_integration')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('get_list_errors_data'))
 def test_xroad_errors(xroad_rest_adapter_mocks, xroad_rest_mocks, migrate_db_for):
@@ -135,7 +128,6 @@ def test_xroad_errors(xroad_rest_adapter_mocks, xroad_rest_mocks, migrate_db_for
 
 
 @pytest.mark.freeze_time('2023-01-17')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 def test_list_xroad_errors_for_organization(migrate_db_for):
     migrate_db_for('xroad_integration')
@@ -168,7 +160,6 @@ def test_list_xroad_errors_for_organization(migrate_db_for):
 
 
 @pytest.mark.freeze_time('2023-01-17')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 def test_view_xroad_errors_for_organization(migrate_db_for, app):
     migrate_db_for('xroad_integration')
@@ -200,7 +191,6 @@ def test_view_xroad_errors_for_organization(migrate_db_for, app):
 
 @pytest.mark.freeze_time('2022-01-02')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getListOfServices'))
 def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_service_list')
@@ -254,7 +244,6 @@ def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
     ]
 )
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getListOfServices'))
 def test_fetch_xroad_service_list_with_date_ranges(xroad_rest_mocks,
@@ -265,7 +254,6 @@ def test_fetch_xroad_service_list_with_date_ranges(xroad_rest_mocks,
 
 @pytest.mark.freeze_time('2022-01-02')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getServiceStatistics'))
 def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_stats')
@@ -314,7 +302,6 @@ def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
     ]
 )
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getServiceStatistics'))
 def test_fetch_xroad_service_statistics_with_date_ranges(xroad_rest_mocks,
@@ -325,7 +312,6 @@ def test_fetch_xroad_service_statistics_with_date_ranges(xroad_rest_mocks,
 
 @pytest.mark.freeze_time('2022-01-02')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getDistinctServiceStatistics'))
 def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_database_setup):
@@ -373,7 +359,6 @@ def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_databas
     ]
 )
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getDistinctServiceStatistics'))
 def test_fetch_xroad_distinct_service_statistics_with_date_ranges(xroad_rest_mocks,
@@ -383,7 +368,6 @@ def test_fetch_xroad_distinct_service_statistics_with_date_ranges(xroad_rest_moc
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('heartbeat'))
 def test_xroad_heartbeat(xroad_rest_mocks):
     result = call_action('fetch_xroad_heartbeat')
@@ -391,9 +375,7 @@ def test_xroad_heartbeat(xroad_rest_mocks):
     assert result['success'] is True
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup', 'xroad_database_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
-                                         'xroad_harvester xroad_integration')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getOrganizationOrganizationData'))
 def test_xroad_get_organizations_organization_data(xroad_rest_mocks):
@@ -419,9 +401,7 @@ def test_xroad_get_organizations_organization_data(xroad_rest_mocks):
     assert updated_organization['webpage_address']['en'] == ""
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup', 'xroad_database_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
-                                         'xroad_harvester xroad_integration')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getOrganizationCompanyData'))
 def test_xroad_get_organizations_company_data(xroad_rest_adapter_mocks, xroad_rest_mocks):
@@ -444,9 +424,7 @@ def test_xroad_get_organizations_company_data(xroad_rest_adapter_mocks, xroad_re
     assert 'old_business_ids' not in updated_organization
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup', 'xroad_database_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
-                                         'xroad_harvester xroad_integration')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getOrganizationCompanyDataWithBusinessIdChanges'))
 def test_xroad_get_organizations_company_data_with_business_id_changes(xroad_rest_adapter_mocks, xroad_rest_mocks):
@@ -462,9 +440,7 @@ def test_xroad_get_organizations_company_data_with_business_id_changes(xroad_res
     assert updated_organization['old_business_ids'] == ['124567-8', '7654321-8']
 
 
-@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'harvest_setup', 'xroad_database_setup')
-@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
-                                         'xroad_harvester xroad_integration')
+@pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getOrganizationEmptyData'))
 def test_xroad_get_organizations_empty_data(xroad_rest_adapter_mocks, xroad_rest_mocks):
     harvester = XRoadHarvesterPlugin()

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -48,6 +48,7 @@ def test_base(xroad_rest_adapter_mocks):
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
 def test_base_twice(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     url = xroad_rest_adapter_url('base')
@@ -57,6 +58,8 @@ def test_base_twice(xroad_rest_adapter_mocks):
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
+                                         'xroad_harvester xroad_integration')
 def test_delete(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     run_harvest(url=xroad_rest_adapter_url('base'), harvester=harvester)
@@ -92,6 +95,7 @@ def test_delete(xroad_rest_adapter_mocks):
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
 def test_listmembers_on_error(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     results = run_harvest(url=xroad_rest_adapter_url('listmembers_error'), harvester=harvester)
@@ -104,6 +108,8 @@ def test_listmembers_on_error(xroad_rest_adapter_mocks):
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
+                                         'xroad_harvester xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('get_list_errors_data'))
 def test_xroad_errors(xroad_rest_adapter_mocks, xroad_rest_mocks, migrate_db_for):
@@ -130,6 +136,7 @@ def test_xroad_errors(xroad_rest_adapter_mocks, xroad_rest_mocks, migrate_db_for
 
 @pytest.mark.freeze_time('2023-01-17')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 def test_list_xroad_errors_for_organization(migrate_db_for):
     migrate_db_for('xroad_integration')
 
@@ -162,6 +169,7 @@ def test_list_xroad_errors_for_organization(migrate_db_for):
 
 @pytest.mark.freeze_time('2023-01-17')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 def test_view_xroad_errors_for_organization(migrate_db_for, app):
     migrate_db_for('xroad_integration')
 
@@ -192,6 +200,7 @@ def test_view_xroad_errors_for_organization(migrate_db_for, app):
 
 @pytest.mark.freeze_time('2022-01-02')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getListOfServices'))
 def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_service_list')
@@ -245,6 +254,7 @@ def test_fetch_xroad_service_list(xroad_rest_mocks, xroad_database_setup):
     ]
 )
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getListOfServices'))
 def test_fetch_xroad_service_list_with_date_ranges(xroad_rest_mocks,
@@ -255,6 +265,7 @@ def test_fetch_xroad_service_list_with_date_ranges(xroad_rest_mocks,
 
 @pytest.mark.freeze_time('2022-01-02')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getServiceStatistics'))
 def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
     result = call_action('fetch_xroad_stats')
@@ -303,6 +314,7 @@ def test_fetch_xroad_service_statistics(xroad_rest_mocks, xroad_database_setup):
     ]
 )
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getServiceStatistics'))
 def test_fetch_xroad_service_statistics_with_date_ranges(xroad_rest_mocks,
@@ -313,6 +325,7 @@ def test_fetch_xroad_service_statistics_with_date_ranges(xroad_rest_mocks,
 
 @pytest.mark.freeze_time('2022-01-02')
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getDistinctServiceStatistics'))
 def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_database_setup):
@@ -360,6 +373,7 @@ def test_fetch_xroad_distinct_service_statistics(xroad_rest_mocks, xroad_databas
     ]
 )
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getDistinctServiceStatistics'))
 def test_fetch_xroad_distinct_service_statistics_with_date_ranges(xroad_rest_mocks,
@@ -369,6 +383,7 @@ def test_fetch_xroad_distinct_service_statistics_with_date_ranges(xroad_rest_moc
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('heartbeat'))
 def test_xroad_heartbeat(xroad_rest_mocks):
     result = call_action('fetch_xroad_heartbeat')
@@ -377,6 +392,8 @@ def test_xroad_heartbeat(xroad_rest_mocks):
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
+@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
+                                         'xroad_harvester xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getOrganizationOrganizationData'))
 def test_xroad_get_organizations_organization_data(xroad_rest_mocks):
@@ -403,6 +420,8 @@ def test_xroad_get_organizations_organization_data(xroad_rest_mocks):
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
+@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
+                                         'xroad_harvester xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getOrganizationCompanyData'))
 def test_xroad_get_organizations_company_data(xroad_rest_adapter_mocks, xroad_rest_mocks):
@@ -426,6 +445,8 @@ def test_xroad_get_organizations_company_data(xroad_rest_adapter_mocks, xroad_re
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
+@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
+                                         'xroad_harvester xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address',
                          xroad_rest_service_url('getOrganizationCompanyDataWithBusinessIdChanges'))
 def test_xroad_get_organizations_company_data_with_business_id_changes(xroad_rest_adapter_mocks, xroad_rest_mocks):
@@ -442,6 +463,8 @@ def test_xroad_get_organizations_company_data_with_business_id_changes(xroad_res
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index', 'xroad_database_setup')
+@pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
+                                         'xroad_harvester xroad_integration')
 @pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getOrganizationEmptyData'))
 def test_xroad_get_organizations_empty_data(xroad_rest_adapter_mocks, xroad_rest_mocks):
     harvester = XRoadHarvesterPlugin()

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
 def test_base(xroad_rest_adapter_mocks):
 
     results = run_harvest(

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,14 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 
 pytest_plugins = [
     u'ckanext.harvest.tests.fixtures',
     u'ckanext.xroad_integration.tests.fixtures'
 ]
+
+
+@pytest.fixture
+def clean_db(reset_db, migrate_db_for):
+    reset_db()
+    migrate_db_for("harvest")

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 pytest-ckan
 pytest-cov
-types-requests
+types-requests==2.25.1

--- a/test.ini
+++ b/test.ini
@@ -14,7 +14,7 @@ use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here.
 ckan.locale_default = fi
-#ckan.plugins = apicatalog scheming_datasets scheming_organizations fluent harvest xroad_harvester xroad_integration
+ckan.plugins = apicatalog scheming_datasets scheming_organizations fluent harvest xroad_harvester xroad_integration
 ckanext.xroad_integration.xroad_environment = 'FI-TEST'
 ckanext.xroad_integration.xroad_catalog_address = http://localhost
 ckanext.xroad_integration.xroad_client_id = someid

--- a/test.ini
+++ b/test.ini
@@ -14,7 +14,7 @@ use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here.
 ckan.locale_default = fi
-ckan.plugins = apicatalog scheming_datasets scheming_organizations fluent harvest xroad_harvester xroad_integration
+ckan.plugins = harvest apicatalog scheming_datasets scheming_organizations fluent xroad_harvester xroad_integration
 ckanext.xroad_integration.xroad_environment = 'FI-TEST'
 ckanext.xroad_integration.xroad_catalog_address = http://localhost
 ckanext.xroad_integration.xroad_client_id = someid


### PR DESCRIPTION
Does not yet do anything with the property but harvester should not fail.
Adds serviceType to harvester class and mock responses.
locks down types-request version to same that ckan uses which should prevent dependency conflicts.
Harvest has moved to alembic migration for database initialization so that needed some updates in tests.