### PR TITLE
LIKA-588: Use serviceType from xroad

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,6 @@ jobs:
           ckan -c test.ini db upgrade -p harvest
           ckan -c test.ini xroad init-db
           
-          # Disable plugins in test.ini
-          sed -i -e 's/ckan.plugins/#ckan.plugins/' test.ini
       - name: Run tests
         run: pytest --ckan-ini=test.ini --cov=ckanext.xroad_integration --disable-warnings ckanext/xroad_integration/tests
       - name: Coveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,8 @@ jobs:
           ckan -c test.ini db upgrade -p harvest
           ckan -c test.ini xroad init-db
           
+          # Disable plugins in test.ini
+          sed -i -e 's/ckan.plugins/#ckan.plugins/' test.ini
       - name: Run tests
         run: pytest --ckan-ini=test.ini --cov=ckanext.xroad_integration --disable-warnings ckanext/xroad_integration/tests
       - name: Coveralls

--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -217,24 +217,6 @@ class XRoadHarvesterPlugin(HarvesterBase):
                         else:
                             log.warn(f'Empty OpenApi service description returned for {generate_service_name(service)}')
 
-                    service_type = self._get_service_type(harvest_object.source.url,
-                                                          dataset.get('xRoadInstance'),
-                                                          dataset.get('xRoadMemberClass'),
-                                                          dataset.get('xRoadMemberCode'),
-                                                          subsystem.subsystem_code,
-                                                          service.service_code,
-                                                          service.service_version)
-                    if type(service_type) is dict:
-                        # Don't generate error if the error is unknown service
-                        if service_type.get('error') == 'Unknown service':
-                            log.info(service_type.get('error'))
-                        else:
-                            self._save_object_error(service_type.get('error'), harvest_object, 'Fetch')
-                    elif not service_type:
-                        log.info(f'Service type is unknown for subsystem {subsystem.subsystem_code} '
-                                 f'service {service.service_code}')
-                    else:
-                        service.service_type = service_type
 
                 dataset['subsystem_pickled'] = subsystem.serialize()
                 dataset['subsystem_dict'] = json.loads(subsystem.serialize_json())

--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -217,7 +217,6 @@ class XRoadHarvesterPlugin(HarvesterBase):
                         else:
                             log.warn(f'Empty OpenApi service description returned for {generate_service_name(service)}')
 
-
                 dataset['subsystem_pickled'] = subsystem.serialize()
                 dataset['subsystem_dict'] = json.loads(subsystem.serialize_json())
                 harvest_object.content = json.dumps(dataset)

--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -360,7 +360,7 @@ class XRoadHarvesterPlugin(HarvesterBase):
                 'name': name,
                 'xroad_servicecode': service.service_code,
                 'xroad_serviceversion': service.service_version,
-                # TODO: use data from xroad catalog 'xroad_service_type': service.service_type,
+                'xroad_service_type': service.serviceType,
                 'harvested_from_xroad': True,
                 'access_restriction_level': 'public'
             }

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -42,9 +42,15 @@ def test_base(xroad_rest_adapter_mocks):
 
     # Subsystem with one unknown type service
     assert len(results['TEST.ORG.000003-3.OneEmptyServiceSubsystem']['dataset']['resources']) == 1
+    assert results['TEST.ORG.000003-3.OneEmptyServiceSubsystem']['dataset']['resources'][0]['xroad_service_type'] == "UNKNOWN"
 
-    # Subsystem with two unknown type services, one soap service and one rest service
-    assert len(results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources']) == 4
+    # Subsystem with two unknown type services, one soap service, one openapi service and one rest service
+    assert len(results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources']) == 5
+    assert results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources'][0]['xroad_service_type'] == "UNKNOWN"
+    assert results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources'][1]['xroad_service_type'] == "UNKNOWN"
+    assert results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources'][2]['xroad_service_type'] == "SOAP"
+    assert results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources'][3]['xroad_service_type'] == "OPENAPI"
+    assert results['TEST.ORG.000003-3.LargeSubsystem']['dataset']['resources'][4]['xroad_service_type'] == "REST"
 
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')

--- a/test.ini
+++ b/test.ini
@@ -14,7 +14,6 @@ use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here.
 ckan.locale_default = fi
-ckan.plugins = harvest apicatalog scheming_datasets scheming_organizations fluent xroad_harvester xroad_integration
 ckanext.xroad_integration.xroad_environment = 'FI-TEST'
 ckanext.xroad_integration.xroad_catalog_address = http://localhost
 ckanext.xroad_integration.xroad_client_id = someid

--- a/test.ini
+++ b/test.ini
@@ -14,6 +14,7 @@ use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
 # Insert any custom config settings to be used when running your extension's
 # tests here.
 ckan.locale_default = fi
+#ckan.plugins = harvest apicatalog scheming_datasets scheming_organizations fluent xroad_harvester xroad_integration
 ckanext.xroad_integration.xroad_environment = 'FI-TEST'
 ckanext.xroad_integration.xroad_catalog_address = http://localhost
 ckanext.xroad_integration.xroad_client_id = someid


### PR DESCRIPTION
Local tests were failing as plugins configuration in test.ini was used instead of test case specific configuration, it's commented away now as CI need to enable it for database initialization.

Otherwise maps serviceType to xroad_service_type and adds assertations to tests.