### PR TITLE
Lika 393 getrest support

### DIFF
--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -218,7 +218,6 @@ class XRoadHarvesterPlugin(HarvesterBase):
                         else:
                             log.warn(f'Empty OpenApi service description returned for {generate_service_name(service)}')
 
-                    log.warning(f'service type: {service.service_type}')
                     if service.service_type.lower() == 'rest':
                         try:
                             path = '/'.join(['getRest', dataset['xRoadInstance'], dataset['xRoadMemberClass'], dataset['xRoadMemberCode'],

--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -220,8 +220,12 @@ class XRoadHarvesterPlugin(HarvesterBase):
 
                     if service.service_type.lower() == 'rest':
                         try:
-                            path = '/'.join(['getRest', dataset['xRoadInstance'], dataset['xRoadMemberClass'], dataset['xRoadMemberCode'],
-                                             subsystem.subsystem_code, service.service_code])
+                            path = '/'.join(['getRest',
+                                             dataset['xRoadInstance'],
+                                             dataset['xRoadMemberClass'],
+                                             dataset['xRoadMemberCode'],
+                                             subsystem.subsystem_code,
+                                             service.service_code])
                             rest_services_data = xroad_catalog_query_json(path)
                             service.rest_services = RestServices.from_dict(rest_services_data)
                         except ContentFetchError:

--- a/ckanext/xroad_integration/harvesters/xroad_types.py
+++ b/ckanext/xroad_integration/harvesters/xroad_types.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass, field
 from typing import Optional, List
 from datetime import datetime
 
-from .xroad_types_utils import Base, optional, date_value, class_value, xroad_list_value, xroad_service_version_value
+from .xroad_types_utils import (Base, optional, date_value, class_value, xroad_list_value,
+                                xroad_service_version_value, class_list_value)
 
 
 @dataclass
@@ -11,6 +12,38 @@ class Error(Base):
     code: str
     string: str
     detail: str
+
+
+@dataclass
+class RestServiceEndpoint(Base):
+    method: str
+    path: str
+
+
+@dataclass
+class RestService(Base):
+    field_map = {'endpointList': 'endpoints',
+                 'xroadInstance': 'instance',
+                 'memberClass': 'member_class',
+                 'memberCode': 'member_code',
+                 'subsystemCode': 'subsystem_code',
+                 'serviceCode': 'service_code',
+                 'serviceVersion': 'service_version'}
+    value_map = {'endpoints': class_list_value(RestServiceEndpoint)}
+    endpoints: List[RestServiceEndpoint]
+    instance: str
+    member_class: str
+    member_code: str
+    subsystem_code: str
+    service_code: str
+    service_version: str
+
+
+@dataclass
+class RestServices(Base):
+    field_map = {'listOfServices': 'services'}
+    value_map = {'services': class_list_value(RestService)}
+    services: List[RestService]
 
 
 @dataclass
@@ -33,7 +66,8 @@ class ServiceDescription(Base):
 @dataclass
 class Service(Base):
     field_map = {'serviceCode': 'service_code',
-                 'serviceVersion': 'service_version'}
+                 'serviceVersion': 'service_version',
+                 'serviceType': 'service_type'}
     value_map = {
             'service_version': xroad_service_version_value,
             'wsdl': optional(class_value(ServiceDescription)),
@@ -48,10 +82,11 @@ class Service(Base):
     changed: datetime
     fetched: datetime
     service_version: Optional[str] = field(default=None)
-    serviceType: Optional[str] = field(default=None)
+    service_type: Optional[str] = field(default=None)
     wsdl: Optional[ServiceDescription] = field(default=None)
     openapi: Optional[ServiceDescription] = field(default=None)
     removed: Optional[datetime] = field(default=None)
+    rest_services: Optional[RestServices] = field(default=None)
 
 
 @dataclass

--- a/ckanext/xroad_integration/harvesters/xroad_types_utils.py
+++ b/ckanext/xroad_integration/harvesters/xroad_types_utils.py
@@ -119,3 +119,9 @@ date_value = iso8601.parse_date
 
 def class_value(cls):
     return cls.from_dict
+
+
+def class_list_value(cls):
+    def parse(items) -> List[cls]:
+        return [cls.from_dict(item) for item in items]
+    return parse

--- a/ckanext/xroad_integration/logic/action.py
+++ b/ckanext/xroad_integration/logic/action.py
@@ -6,60 +6,29 @@ import iso8601
 from dateutil import relativedelta
 from sqlalchemy import and_, not_
 
-import requests
 import datetime
 import six
 
 from ckan import model
 from requests.exceptions import ConnectionError
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 from ckan.plugins import toolkit
 from pprint import pformat
-from typing import Dict, Any, List, Union
 
 from ckanext.xroad_integration.model import (XRoadError, XRoadStat, XRoadServiceList, XRoadServiceListMember,
                                              XRoadServiceListSubsystem, XRoadServiceListService,
                                              XRoadServiceListSecurityServer, XRoadBatchResult, XRoadDistinctServiceStat,
                                              XRoadHeartbeat)
+from ckanext.xroad_integration.xroad_utils import xroad_catalog_query_json, ContentFetchError, http
 
-
-# Type for json
-Json = Union[Dict[str, "Json"], List["Json"], str, int, float, bool, None]
 
 # PUBLIC_ORGANIZATION_CLASSES = ['GOV', 'MUN', 'ORG']
 # COMPANY_CLASSES = ['COM']
 
-DEFAULT_TIMEOUT = 3  # seconds
 DEFAULT_DAYS_TO_FETCH = 1
 DEFAULT_LIST_ERRORS_HISTORY_IN_DAYS = 90
 DEFAULT_LIST_ERRORS_PAGE_LIMIT = 20
 
-
-# Add default timeout
-class TimeoutHTTPAdapter(HTTPAdapter):
-    def __init__(self, *args, **kwargs):
-        self.timeout = DEFAULT_TIMEOUT
-        if "timeout" in kwargs:
-            self.timeout = kwargs["timeout"]
-            del kwargs["timeout"]
-        super(TimeoutHTTPAdapter, self).__init__(*args, **kwargs)
-
-
-retry_strategy = Retry(
-    total=3,
-    backoff_factor=1
-)
-
-adapter = TimeoutHTTPAdapter(max_retries=retry_strategy)
-http = requests.Session()
-http.mount("http://", adapter)
-
 log = logging.getLogger(__name__)
-
-
-class ContentFetchError(Exception):
-    pass
 
 
 def update_xroad_organizations(context, data_dict):
@@ -494,64 +463,6 @@ def _fetch_error_page(params, queryparams, pagination) -> (int, int):
         error_count = error_count + 1
 
     return error_data.get('numberOfPages', 0), error_count
-
-
-def xroad_catalog_query(service, params: List = None,
-                        queryparams: Dict[str, Any] = None, content_type='application/json', accept='application/json',
-                        pagination: Dict[str, str] = None):
-    if params is None:
-        params = []
-    if queryparams is None:
-        queryparams = {}
-
-    xroad_catalog_address = toolkit.config.get('ckanext.xroad_integration.xroad_catalog_address', '')  # type: str
-    xroad_catalog_certificate = toolkit.config.get('ckanext.xroad_integration.xroad_catalog_certificate')
-    xroad_client_id = toolkit.config.get('ckanext.xroad_integration.xroad_client_id')
-    xroad_client_certificate = toolkit.config.get('ckanext.xroad_integration.xroad_client_certificate')
-
-    if not xroad_catalog_address.startswith('http'):
-        log.warn("Invalid X-Road catalog url %s" % xroad_catalog_address)
-        raise ContentFetchError("Invalid X-Road catalog url %s" % xroad_catalog_address)
-
-    url = '{address}/{service}'.format(address=xroad_catalog_address, service=service)
-
-    if pagination:
-        queryparams['page'] = pagination['page']
-        queryparams['limit'] = pagination['limit']
-
-    for param in params:
-        url += '/' + param
-
-    headers = {'Accept': accept,
-               'Content-Type': content_type,
-               'X-Road-Client': xroad_client_id}
-
-    certificate_args = {}
-    if xroad_catalog_certificate and os.path.isfile(xroad_catalog_certificate):
-        certificate_args['verify'] = xroad_catalog_certificate
-    else:
-        certificate_args['verify'] = False
-
-    if xroad_client_certificate and os.path.isfile(xroad_client_certificate):
-        certificate_args['cert'] = xroad_client_certificate
-
-    return http.get(url, params=queryparams, headers=headers, **certificate_args)
-
-
-def xroad_catalog_query_json(service, params: List = None, queryparams: Dict[str, Any] = None,
-                             pagination: Dict[str, str] = None) -> Json:
-    if params is None:
-        params = []
-    if queryparams is None:
-        queryparams = {}
-    response = xroad_catalog_query(service, params=params, queryparams=queryparams, pagination=pagination)
-    if response.status_code == 204:
-        log.warning("Received empty response for service %s", service)
-        return
-    try:
-        return response.json()
-    except requests.exceptions.JSONDecodeError as e:
-        raise ContentFetchError(f'Expected JSON: {e}')
 
 
 def fetch_xroad_service_list(context, data_dict):

--- a/ckanext/xroad_integration/tests/fixtures.py
+++ b/ckanext/xroad_integration/tests/fixtures.py
@@ -51,7 +51,11 @@ XROAD_REST_SERVICES = {
     'get_list_errors_data': {
         'host': '127.0.0.1',
         'port': 9199,
-        'content': 'xroad-catalog-mock-responses/test_list_errors.json'}
+        'content': 'xroad-catalog-mock-responses/test_list_errors.json'},
+    'getRest': {
+        'host': '127.0.0.1',
+        'port': 9200,
+        'content': 'xroad-catalog-mock-responses/test_getrest.json'},
     }
 
 

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -19,8 +19,7 @@ log = logging.getLogger(__name__)
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 @pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
-@pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getRest'))
-def test_base(xroad_rest_adapter_mocks, xroad_rest_mocks):
+def test_base(xroad_rest_adapter_mocks):
 
     results = run_harvest(
         url=xroad_rest_adapter_url('base'),
@@ -56,8 +55,7 @@ def test_base(xroad_rest_adapter_mocks, xroad_rest_mocks):
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 @pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
-@pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getRest'))
-def test_base_twice(xroad_rest_adapter_mocks, xroad_rest_mocks):
+def test_base_twice(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     url = xroad_rest_adapter_url('base')
     config = json.dumps({"force_all": True})
@@ -68,8 +66,7 @@ def test_base_twice(xroad_rest_adapter_mocks, xroad_rest_mocks):
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 @pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
                                          'xroad_harvester xroad_integration')
-@pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getRest'))
-def test_delete(xroad_rest_adapter_mocks, xroad_rest_mocks):
+def test_delete(xroad_rest_adapter_mocks):
     harvester = XRoadHarvesterPlugin()
     run_harvest(url=xroad_rest_adapter_url('base'), harvester=harvester)
 

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -19,7 +19,8 @@ log = logging.getLogger(__name__)
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 @pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
-def test_base(xroad_rest_adapter_mocks):
+@pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getRest'))
+def test_base(xroad_rest_adapter_mocks, xroad_rest_mocks):
 
     results = run_harvest(
         url=xroad_rest_adapter_url('base'),
@@ -55,7 +56,8 @@ def test_base(xroad_rest_adapter_mocks):
 
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 @pytest.mark.ckan_config('ckan.plugins', 'harvest xroad_harvester')
-def test_base_twice(xroad_rest_adapter_mocks):
+@pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getRest'))
+def test_base_twice(xroad_rest_adapter_mocks, xroad_rest_mocks):
     harvester = XRoadHarvesterPlugin()
     url = xroad_rest_adapter_url('base')
     config = json.dumps({"force_all": True})
@@ -66,7 +68,8 @@ def test_base_twice(xroad_rest_adapter_mocks):
 @pytest.mark.usefixtures('with_plugins', 'clean_db', 'clean_index')
 @pytest.mark.ckan_config('ckan.plugins', 'apicatalog scheming_datasets scheming_organizations fluent harvest '
                                          'xroad_harvester xroad_integration')
-def test_delete(xroad_rest_adapter_mocks):
+@pytest.mark.ckan_config('ckanext.xroad_integration.xroad_catalog_address', xroad_rest_service_url('getRest'))
+def test_delete(xroad_rest_adapter_mocks, xroad_rest_mocks):
     harvester = XRoadHarvesterPlugin()
     run_harvest(url=xroad_rest_adapter_url('base'), harvester=harvester)
 

--- a/ckanext/xroad_integration/tests/test_plugin.py
+++ b/ckanext/xroad_integration/tests/test_plugin.py
@@ -494,4 +494,3 @@ def test_getrest(xroad_rest_adapter_mocks, xroad_rest_mocks):
     rest_service = next(s for s in subsystem.get('resources', []) if s['xroad_servicecode'] == 'restService')
     assert {'method': 'POST', 'path': '/PostSomething/v1'} in rest_service['rest_endpoints']['endpoints']
     assert {'method': 'GET', 'path': '/ComeGetSome/v1'} in rest_service['rest_endpoints']['endpoints']
-

--- a/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
+++ b/ckanext/xroad_integration/tests/xroad_mock/xroad_rest_mock.py
@@ -32,6 +32,19 @@ def create_app(input_file):
     @app.route('/listErrors/<instance>/<code>/<member>')
     def list_errors(instance='TEST', code='000000-0', member='some_member'):
         return mock_data
+
+    @app.route('/getRest/<instance>/<member_class>/<member_code>/<subsystem_code>/<service_code>')
+    @app.route('/getRest/<instance>/<member_class>/<member_code>/<subsystem_code>/<service_code>/<service_version>')
+    def getRest(instance, member_class, member_code, subsystem_code, service_code, service_version=None):
+        result = mock_data.copy()
+        for service in result.get('listOfServices', []):
+            service['xroadInstance'] = instance
+            service['memberClass'] = member_class
+            service['memberCode'] = member_code
+            service['subsystemCode'] = subsystem_code
+            service['serviceCode'] = service_code
+        return result
+
     return app
 
 

--- a/ckanext/xroad_integration/xroad_utils.py
+++ b/ckanext/xroad_integration/xroad_utils.py
@@ -1,0 +1,97 @@
+import os
+from ckan.plugins import toolkit
+from typing import Dict, Any, List, Union
+from logging import getLogger
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+from simplejson.scanner import JSONDecodeError
+
+DEFAULT_TIMEOUT = 3  # seconds
+
+log = getLogger(__name__)
+
+# Type for json
+Json = Union[Dict[str, "Json"], List["Json"], str, int, float, bool, None]
+
+
+# Add default timeout
+class TimeoutHTTPAdapter(HTTPAdapter):
+    def __init__(self, *args, **kwargs):
+        self.timeout = DEFAULT_TIMEOUT
+        if "timeout" in kwargs:
+            self.timeout = kwargs["timeout"]
+            del kwargs["timeout"]
+        super(TimeoutHTTPAdapter, self).__init__(*args, **kwargs)
+
+
+retry_strategy = Retry(
+    total=3,
+    backoff_factor=1
+)
+
+adapter = TimeoutHTTPAdapter(max_retries=retry_strategy)
+http = requests.Session()
+http.mount("http://", adapter)
+
+
+class ContentFetchError(Exception):
+    pass
+
+
+def xroad_catalog_query(service, params: List = None,
+                        queryparams: Dict[str, Any] = None, content_type='application/json', accept='application/json',
+                        pagination: Dict[str, str] = None):
+    if params is None:
+        params = []
+    if queryparams is None:
+        queryparams = {}
+
+    xroad_catalog_address = toolkit.config.get('ckanext.xroad_integration.xroad_catalog_address', '')  # type: str
+    xroad_catalog_certificate = toolkit.config.get('ckanext.xroad_integration.xroad_catalog_certificate')
+    xroad_client_id = toolkit.config.get('ckanext.xroad_integration.xroad_client_id')
+    xroad_client_certificate = toolkit.config.get('ckanext.xroad_integration.xroad_client_certificate')
+
+    if not xroad_catalog_address.startswith('http'):
+        log.warn("Invalid X-Road catalog url %s" % xroad_catalog_address)
+        raise ContentFetchError("Invalid X-Road catalog url %s" % xroad_catalog_address)
+
+    url = '{address}/{service}'.format(address=xroad_catalog_address, service=service)
+
+    if pagination:
+        queryparams['page'] = pagination['page']
+        queryparams['limit'] = pagination['limit']
+
+    for param in params:
+        url += '/' + param
+
+    headers = {'Accept': accept,
+               'Content-Type': content_type,
+               'X-Road-Client': xroad_client_id}
+
+    certificate_args = {}
+    if xroad_catalog_certificate and os.path.isfile(xroad_catalog_certificate):
+        certificate_args['verify'] = xroad_catalog_certificate
+    else:
+        certificate_args['verify'] = False
+
+    if xroad_client_certificate and os.path.isfile(xroad_client_certificate):
+        certificate_args['cert'] = xroad_client_certificate
+
+    return http.get(url, params=queryparams, headers=headers, **certificate_args)
+
+
+def xroad_catalog_query_json(service, params: List = None, queryparams: Dict[str, Any] = None,
+                             pagination: Dict[str, str] = None) -> Json:
+    if params is None:
+        params = []
+    if queryparams is None:
+        queryparams = {}
+    response = xroad_catalog_query(service, params=params, queryparams=queryparams, pagination=pagination)
+    if response.status_code == 204:
+        log.warning("Received empty response for service %s", service)
+        return
+    try:
+        return response.json()
+    except JSONDecodeError as e:
+        raise ContentFetchError(f'Expected JSON: {e}')

--- a/test.ini
+++ b/test.ini
@@ -16,7 +16,7 @@ use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
 ckan.locale_default = fi
 #ckan.plugins = harvest apicatalog scheming_datasets scheming_organizations fluent xroad_harvester xroad_integration
 ckanext.xroad_integration.xroad_environment = 'FI-TEST'
-ckanext.xroad_integration.xroad_catalog_address = http://localhost
+ckanext.xroad_integration.xroad_catalog_address = missing-on-purpose
 ckanext.xroad_integration.xroad_client_id = someid
 ckanext.xroad_integration.unknown_service_link_url = https://example.com
 


### PR DESCRIPTION
- Refactor X-Road REST utilites to `xroad_utils.py`
- Harvester changes:
  - Use `getRest` xroad-catalog endpoint in fetch to get and parse REST service endpoint data
  - Store endpoint data to `rest_endpoints` per service in import stage
- Rename and map `serviceType` field to `service_type`
- Add X-Road types for REST service descriptions
- Added mock implementation and a test for harvesting REST endpoints