### PR TITLE
LIKA-598: Only keep full service descriptions in a compressed format in harvest objects

### DIFF
--- a/ckanext/xroad_integration/cli.py
+++ b/ckanext/xroad_integration/cli.py
@@ -3,6 +3,7 @@
 import json
 import jinja2
 from ckan.lib import mailer
+from ckanext.xroad_integration.harvesters.xroad_types import Subsystem
 
 from datetime import datetime
 
@@ -318,6 +319,22 @@ def send_latest_batch_run_results_email(dryrun):
 
     if dryrun:
         print(msg)
+
+
+@xroad.command()
+@click.pass_context
+@click.argument('object_id')
+def subsystem_from_harvest_object(ctx, object_id):
+    'Decodes a subsystem JSON representation from harvest object '
+    flask_app = ctx.meta["flask_app"]
+    with flask_app.test_request_context():
+        try:
+            result = get_action('harvest_object_show')({'ignore_auth': True}, {'id': object_id})
+            content = json.loads(result['content'])
+            subsystem = Subsystem.deserialize(content['subsystem_pickled'])
+            click.secho(subsystem.serialize_json())
+        except Exception as e:
+            click.secho('Error fetching harvest object: \n %s' % e, fg='red')
 
 
 def _admin_user():

--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -174,7 +174,6 @@ class XRoadHarvesterPlugin(HarvesterBase):
                                         'xRoadMemberClass': member.member_class,
                                         'xRoadMemberCode': member.member_code,
                                         'owner_name': org.get('name'),
-                                        'subsystem_dict': json.loads(subsystem.serialize_json()),
                                         'subsystem_pickled': subsystem.serialize(),
                                     }))
 

--- a/ckanext/xroad_integration/harvesters/xroad_harvester.py
+++ b/ckanext/xroad_integration/harvesters/xroad_harvester.py
@@ -239,6 +239,16 @@ class XRoadHarvesterPlugin(HarvesterBase):
 
                 dataset['subsystem_pickled'] = subsystem.serialize()
                 dataset['subsystem_dict'] = json.loads(subsystem.serialize_json())
+
+                def truncate(obj, field, max_length=1024):
+                    data = obj.get(field)
+                    if isinstance(data, str) and len(data) > max_length:
+                        obj[field] = data[:max_length] + ' (truncated)'
+
+                for service in dataset['subsystem_dict'].get('services', []):
+                    truncate(service, 'wsdl')
+                    truncate(service, 'openapi')
+
                 harvest_object.content = json.dumps(dataset)
                 harvest_object.save()
         except (TypeError, ContentFetchError):

--- a/ckanext/xroad_integration/harvesters/xroad_types_utils.py
+++ b/ckanext/xroad_integration/harvesters/xroad_types_utils.py
@@ -13,6 +13,7 @@ import pickle
 import base64
 import json
 import six
+import lzma
 
 
 class Base(object):
@@ -46,13 +47,13 @@ class Base(object):
 
     @classmethod
     def deserialize(cls, data):
-        obj = pickle.loads(base64.decodebytes(data.encode('utf-8')))
+        obj = pickle.loads(lzma.decompress(base64.decodebytes(data.encode('utf-8'))))
         if not isinstance(obj, cls):
             raise ValueError(f'Deserialized data describes a {type(obj)}, expected {cls}')
         return obj
 
     def serialize(self):
-        return base64.encodebytes(pickle.dumps(self)).decode('utf-8')
+        return base64.encodebytes(lzma.compress(pickle.dumps(self))).decode('utf-8')
 
     # ====== ASSUMPTIONS ======
     # JSON (De)serialization


### PR DESCRIPTION
- Added compression to data type serialize/deserialize
- Truncate long plain service WSDL/OpenAPI descriptions in harvest objects