### PR TITLE
Wrap corner button in a div to ensure it is not a flex item

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9]
+        ckan-version: [2.10]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.10]
+        ckan-version: ["2.10"]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}

--- a/ckanext/xroad_integration/templates/admin/xroad_services.html
+++ b/ckanext/xroad_integration/templates/admin/xroad_services.html
@@ -7,7 +7,9 @@
 {% asset "apicatalog/datetimepicker_js" %}
 {% asset "apicatalog/datetimepicker_css" %}
 
-<a href="{{ h.url_for('xroad.services', date=selected_date, format='csv') }}" class="btn btn-primary pull-right">{{ _('Download CSV') }}</a>
+<div>
+  <a href="{{ h.url_for('xroad.services', date=selected_date, format='csv') }}" class="btn btn-primary pull-right">{{ _('Download CSV') }}</a>
+</div>
     <form method="get" action="">
       {{ form.input('date', id='field-date', label=_('Date'), placeholder=_('2005-01-01'), value=selected_date, classes=[], attrs={'data-module': 'datepicker', 'data-date-format': 'YYYY-MM-DD', 'autosubmit': True}) }}
     </form>


### PR DESCRIPTION
Bootstrap upgrade makes the wrapping row a flex container which breaks the button sizing. Wrapping it in a div works for both old and new bootstrap cases.